### PR TITLE
Add support for UnleashContext #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ provided by unleash.
 - RemoteAddressStrategy
 - ApplicationHostnameStrategy
 
-Read more about the strategies in [activation-strategy.md](https://github.com/Unleash/unleash/blob/master/docs/activation-strategies.md);
+Read more about the strategies in [activation-strategy.md](https://github.com/Unleash/unleash/blob/master/docs/activation-strategies.md).
 
 #### Custom strategies
 You may also specify and implement your own strategy. The specification must be registered in the Unleash UI and 

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -1,6 +1,8 @@
 package no.finn.unleash;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import no.finn.unleash.metric.UnleashMetricService;
@@ -9,15 +11,28 @@ import no.finn.unleash.repository.FeatureToggleRepository;
 import no.finn.unleash.repository.ToggleBackupHandlerFile;
 import no.finn.unleash.repository.HttpToggleFetcher;
 import no.finn.unleash.repository.ToggleRepository;
+import no.finn.unleash.strategy.ApplicationHostnameStrategy;
 import no.finn.unleash.strategy.DefaultStrategy;
+import no.finn.unleash.strategy.GradualRolloutRandomStrategy;
+import no.finn.unleash.strategy.GradualRolloutSessionIdStrategy;
+import no.finn.unleash.strategy.GradualRolloutUserIdStrategy;
+import no.finn.unleash.strategy.RemoteAddressStrategy;
 import no.finn.unleash.strategy.Strategy;
 import no.finn.unleash.strategy.UnknownStrategy;
+import no.finn.unleash.strategy.UserWithIdStrategy;
 import no.finn.unleash.util.UnleashConfig;
 import no.finn.unleash.util.UnleashScheduledExecutor;
 import no.finn.unleash.util.UnleashScheduledExecutorImpl;
 
 public final class DefaultUnleash implements Unleash {
-    private static final DefaultStrategy DEFAULT_STRATEGY = new DefaultStrategy();
+    private static final List<Strategy> BUILTIN_STRATEGIES = Arrays.asList(new DefaultStrategy(),
+            new ApplicationHostnameStrategy(),
+            new GradualRolloutRandomStrategy(),
+            new GradualRolloutSessionIdStrategy(),
+            new GradualRolloutUserIdStrategy(),
+            new RemoteAddressStrategy(),
+            new UserWithIdStrategy());
+
     private static final UnknownStrategy UNKNOWN_STRATEGY = new UnknownStrategy();
     private static final UnleashScheduledExecutor unleashScheduledExecutor = new UnleashScheduledExecutorImpl();
 
@@ -80,7 +95,7 @@ public final class DefaultUnleash implements Unleash {
     private Map<String, Strategy> buildStrategyMap(Strategy[] strategies) {
         Map<String, Strategy> map = new HashMap<>();
 
-        map.put(DEFAULT_STRATEGY.getName(), DEFAULT_STRATEGY);
+        BUILTIN_STRATEGIES.forEach(strategy -> map.put(strategy.getName(), strategy));
 
         if (strategies != null) {
             for (Strategy strategy : strategies) {
@@ -93,10 +108,6 @@ public final class DefaultUnleash implements Unleash {
 
 
     private Strategy getStrategy(String strategy) {
-        if (strategyMap.containsKey(strategy)) {
-            return strategyMap.get(strategy);
-        } else {
-            return UNKNOWN_STRATEGY;
-        }
+        return strategyMap.containsKey(strategy) ? strategyMap.get(strategy) : UNKNOWN_STRATEGY;
     }
 }

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -52,6 +52,11 @@ public final class DefaultUnleash implements Unleash {
 
     @Override
     public boolean isEnabled(final String toggleName, final boolean defaultSetting) {
+        return isEnabled(toggleName, UnleashContext.builder().build(), defaultSetting);
+    }
+
+    @Override
+    public boolean isEnabled(final String toggleName, final UnleashContext context ,final boolean defaultSetting) {
         boolean enabled = false;
         FeatureToggle featureToggle = toggleRepository.getToggle(toggleName);
 

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -4,4 +4,12 @@ public interface Unleash {
     boolean isEnabled(String toggleName);
 
     boolean isEnabled(String toggleName, boolean defaultSetting);
+
+    default boolean isEnabled(String toggleName, UnleashContext context) {
+        return isEnabled(toggleName, context, false);
+    }
+
+    default boolean isEnabled(String toggleName, UnleashContext context, boolean defaultSetting) {
+        return isEnabled(toggleName, defaultSetting);
+    }
 }

--- a/src/main/java/no/finn/unleash/UnleashContext.java
+++ b/src/main/java/no/finn/unleash/UnleashContext.java
@@ -51,7 +51,7 @@ public class UnleashContext {
         }
 
         public Builder sessionId(String sessionId) {
-            this.userId = sessionId;
+            this.sessionId = sessionId;
             return this;
         }
 

--- a/src/main/java/no/finn/unleash/UnleashContext.java
+++ b/src/main/java/no/finn/unleash/UnleashContext.java
@@ -1,0 +1,74 @@
+package no.finn.unleash;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class UnleashContext {
+    private final Optional<String> userId;
+    private final Optional<String> sessionId;
+    private final Optional<String> remoteAddress;
+
+    private final Map<String, String> properties;
+
+    public UnleashContext(String userId, String sessionId, String remoteAddress, Map<String, String> properties) {
+        this.userId = Optional.ofNullable(userId);
+        this.sessionId = Optional.ofNullable(sessionId);
+        this.remoteAddress = Optional.ofNullable(remoteAddress);
+        this.properties = properties;
+    }
+
+    public Optional<String> getUserId() {
+        return userId;
+    }
+
+    public Optional<String> getSessionId() {
+        return sessionId;
+    }
+
+    public Optional<String> getRemoteAddress() {
+        return remoteAddress;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String userId;
+        private String sessionId;
+        private String remoteAddress;
+
+        private final Map<String, String> properties = new HashMap<>();
+
+        public Builder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder sessionId(String sessionId) {
+            this.userId = sessionId;
+            return this;
+        }
+
+        public Builder remoteAddress(String remoteAddress) {
+            this.remoteAddress = remoteAddress;
+            return this;
+        }
+
+        public Builder addProperty(String name, String value) {
+            properties.put(name, value);
+            return this;
+        }
+
+        public UnleashContext build() {
+            return new UnleashContext(userId, sessionId, remoteAddress, properties);
+        }
+    }
+
+
+}

--- a/src/main/java/no/finn/unleash/UnleashContextProvider.java
+++ b/src/main/java/no/finn/unleash/UnleashContextProvider.java
@@ -2,4 +2,8 @@ package no.finn.unleash;
 
 public interface UnleashContextProvider {
     UnleashContext getContext();
+
+    static UnleashContextProvider getDefaultProvider() {
+        return () -> UnleashContext.builder().build();
+    }
 }

--- a/src/main/java/no/finn/unleash/UnleashContextProvider.java
+++ b/src/main/java/no/finn/unleash/UnleashContextProvider.java
@@ -1,0 +1,5 @@
+package no.finn.unleash;
+
+public interface UnleashContextProvider {
+    UnleashContext getContext();
+}

--- a/src/main/java/no/finn/unleash/strategy/ApplicationHostnameStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/ApplicationHostnameStrategy.java
@@ -1,0 +1,42 @@
+package no.finn.unleash.strategy;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+public class ApplicationHostnameStrategy implements Strategy {
+    public static final String HOST_NAMES_PARAM = "hostNames";
+    protected final String NAME = "applicationHostname";
+    private final String hostname;
+
+    public ApplicationHostnameStrategy() {
+        this.hostname = resolveHostname();
+    }
+
+    private String resolveHostname() {
+        String hostname =  System.getProperty("hostname");
+        if(hostname == null) {
+            try {
+                hostname = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e) {
+                hostname = "undefined";
+            }
+        }
+        return hostname;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return Optional.ofNullable(parameters.get(HOST_NAMES_PARAM))
+                .map(hostString -> hostString.toLowerCase())
+                .map(hostString -> Arrays.asList(hostString.split("\\s?,\\s?")))
+                .map(hostList -> hostList.contains(hostname)).orElse(false);
+    }
+}

--- a/src/main/java/no/finn/unleash/strategy/ApplicationHostnameStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/ApplicationHostnameStrategy.java
@@ -36,7 +36,8 @@ public class ApplicationHostnameStrategy implements Strategy {
     public boolean isEnabled(Map<String, String> parameters) {
         return Optional.ofNullable(parameters.get(HOST_NAMES_PARAM))
                 .map(hostString -> hostString.toLowerCase())
-                .map(hostString -> Arrays.asList(hostString.split("\\s?,\\s?")))
-                .map(hostList -> hostList.contains(hostname)).orElse(false);
+                .map(hostString -> Arrays.asList(hostString.split(",\\s*")))
+                .map(hostList -> hostList.contains(hostname.toLowerCase()))
+                .orElse(false);
     }
 }

--- a/src/main/java/no/finn/unleash/strategy/GradualRolloutRandomStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/GradualRolloutRandomStrategy.java
@@ -7,7 +7,7 @@ import java.util.Random;
 import no.finn.unleash.strategy.Strategy;
 
 public final class GradualRolloutRandomStrategy implements Strategy {
-
+    protected static final String PERCENTAGE = "percentage";
     private static final String STRATEGY_NAME = "gradualRolloutRandom";
 
     private final Random random;
@@ -27,10 +27,8 @@ public final class GradualRolloutRandomStrategy implements Strategy {
 
     @Override
     public boolean isEnabled(final Map<String, String> parameters) {
-        return Optional.ofNullable(parameters.get("percentage"))
-                .filter(percentageStr -> percentageStr.matches("^100|0|[1-9][0-9]?$"))
-                .map(Integer::parseInt)
-                .map(percentage -> percentage >= random.nextInt(100) + 1)
-                .orElse(false);
+        int percentage = StrategyUtils.getPercentage(parameters.get(PERCENTAGE));
+        int randomNumber = random.nextInt(100) + 1;
+        return percentage >= randomNumber;
     }
 }

--- a/src/main/java/no/finn/unleash/strategy/GradualRolloutRandomStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/GradualRolloutRandomStrategy.java
@@ -1,0 +1,36 @@
+package no.finn.unleash.strategy;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+
+import no.finn.unleash.strategy.Strategy;
+
+public final class GradualRolloutRandomStrategy implements Strategy {
+
+    private static final String STRATEGY_NAME = "gradualRolloutRandom";
+
+    private final Random random;
+
+    public GradualRolloutRandomStrategy() {
+        random = new Random();
+    }
+
+    protected GradualRolloutRandomStrategy(long seed) {
+        random = new Random(seed);
+    }
+
+    @Override
+    public String getName() {
+        return STRATEGY_NAME;
+    }
+
+    @Override
+    public boolean isEnabled(final Map<String, String> parameters) {
+        return Optional.ofNullable(parameters.get("percentage"))
+                .filter(percentageStr -> percentageStr.matches("^100|0|[1-9][0-9]?$"))
+                .map(Integer::parseInt)
+                .map(percentage -> percentage >= random.nextInt(100) + 1)
+                .orElse(false);
+    }
+}

--- a/src/main/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategy.java
@@ -6,9 +6,9 @@ import java.util.Optional;
 import no.finn.unleash.UnleashContext;
 
 /**
- * Implements a gradual roll-out strategy based on userId.
+ * Implements a gradual roll-out strategy based on session id.
  *
- * Using this strategy you can target only logged in users and gradually expose your
+ * Using this strategy you can target only users bound to a session and gradually expose your
  * feature to higher percentage of the logged in user.
  *
  * This strategy takes two parameters:
@@ -17,11 +17,11 @@ import no.finn.unleash.UnleashContext;
  *                  toggles you can correlate the user experience across toggles.
  *
  */
-public final class GradualRolloutForUserWithIdStrategy implements Strategy {
+public final class GradualRolloutSessionIdStrategy implements Strategy {
     protected static final String PERCENTAGE = "percentage";
     protected static final String GROUP_ID = "groupId";
 
-    private static final String NAME = "gradualRolloutForUserWithId";
+    private static final String NAME = "gradualRolloutSessionId";
 
     @Override
     public String getName() {
@@ -35,18 +35,18 @@ public final class GradualRolloutForUserWithIdStrategy implements Strategy {
 
     @Override
     public boolean isEnabled(final Map<String, String> parameters, UnleashContext unleashContext) {
-        Optional<String> userId = unleashContext.getUserId();
+        Optional<String> sessionId = unleashContext.getSessionId();
 
-        if(!userId.isPresent()) {
+        if(!sessionId.isPresent()) {
             return false;
         }
 
         final int percentage = StrategyUtils.getPercentage(parameters.get(PERCENTAGE));
         final String groupId = Optional.ofNullable(parameters.get(GROUP_ID)).orElse("");
 
-        final int normalizedUserId = StrategyUtils.getNormalizedNumber(userId.get(), groupId);
+        final int normalizedSessionId = StrategyUtils.getNormalizedNumber(sessionId.get(), groupId);
 
-        return percentage > 0 && normalizedUserId <= percentage;
+        return percentage > 0 && normalizedSessionId <= percentage;
     }
 
 

--- a/src/main/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategy.java
@@ -1,0 +1,54 @@
+package no.finn.unleash.strategy;
+
+import java.util.Map;
+import java.util.Optional;
+
+import no.finn.unleash.UnleashContext;
+
+/**
+ * Implements a gradual roll-out strategy based on userId.
+ *
+ * Using this strategy you can target only logged in users and gradually expose your
+ * feature to higher percentage of the logged in user.
+ *
+ * This strategy takes two parameters:
+ *  - percentage :  a number between 0 and 100. The percentage you want to enable the feature for.
+ *  - groupId :     a groupId used for rolling out the feature. By using the same groupId for different
+ *                  toggles you can correlate the user experience across toggles.
+ *
+ */
+public final class GradualRolloutForUserWithIdStrategy implements Strategy {
+    protected static final String PERCENTAGE = "percentage";
+    protected static final String GROUP_ID = "groupId";
+
+    private static final String NAME = "gradualRolloutForUserWithId";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(final Map<String, String> parameters, UnleashContext unleashContext) {
+        Optional<String> userId = unleashContext.getUserId();
+
+        if(!userId.isPresent()) {
+            return false;
+        }
+
+        final int percentage = StrategyUtils.getPercentage(parameters.get(PERCENTAGE));
+        final String groupId = Optional.ofNullable(parameters.get(GROUP_ID)).orElse("");
+
+        final int normalizedUserId = StrategyUtils.getNormalizedNumber(userId.get(), groupId);
+
+        return percentage > 0 && normalizedUserId <= percentage;
+    }
+
+
+}
+

--- a/src/main/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategy.java
@@ -1,0 +1,54 @@
+package no.finn.unleash.strategy;
+
+import java.util.Map;
+import java.util.Optional;
+
+import no.finn.unleash.UnleashContext;
+
+/**
+ * Implements a gradual roll-out strategy based on userId.
+ *
+ * Using this strategy you can target only logged in users and gradually expose your
+ * feature to higher percentage of the logged in user.
+ *
+ * This strategy takes two parameters:
+ *  - percentage :  a number between 0 and 100. The percentage you want to enable the feature for.
+ *  - groupId :     a groupId used for rolling out the feature. By using the same groupId for different
+ *                  toggles you can correlate the user experience across toggles.
+ *
+ */
+public final class GradualRolloutUserIdStrategy implements Strategy {
+    protected static final String PERCENTAGE = "percentage";
+    protected static final String GROUP_ID = "groupId";
+
+    private static final String NAME = "gradualRolloutUserId";
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(final Map<String, String> parameters, UnleashContext unleashContext) {
+        Optional<String> userId = unleashContext.getUserId();
+
+        if(!userId.isPresent()) {
+            return false;
+        }
+
+        final int percentage = StrategyUtils.getPercentage(parameters.get(PERCENTAGE));
+        final String groupId = Optional.ofNullable(parameters.get(GROUP_ID)).orElse("");
+
+        final int normalizedUserId = StrategyUtils.getNormalizedNumber(userId.get(), groupId);
+
+        return percentage > 0 && normalizedUserId <= percentage;
+    }
+
+
+}
+

--- a/src/main/java/no/finn/unleash/strategy/RemoteAddressStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/RemoteAddressStrategy.java
@@ -1,0 +1,33 @@
+package no.finn.unleash.strategy;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import no.finn.unleash.UnleashContext;
+
+public final class RemoteAddressStrategy implements Strategy {
+
+    protected static final String PARAM = "IPs";
+    private static final String STRATEGY_NAME = "remoteAddress";
+
+
+    @Override
+    public String getName() {
+        return STRATEGY_NAME;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters, UnleashContext context) {
+        return Optional.ofNullable(parameters.get(PARAM))
+                .map(ips -> Arrays.asList(ips.split(",\\s*")))
+                .map(ips -> ips.contains(context.getRemoteAddress().orElse(null)))
+                .orElse(false);
+    }
+
+}

--- a/src/main/java/no/finn/unleash/strategy/Strategy.java
+++ b/src/main/java/no/finn/unleash/strategy/Strategy.java
@@ -1,9 +1,14 @@
 package no.finn.unleash.strategy;
 
 import java.util.Map;
+import no.finn.unleash.UnleashContext;
 
 public interface Strategy {
     String getName();
 
     boolean isEnabled(Map<String, String> parameters);
+
+    default boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {
+        return isEnabled(parameters);
+    }
 }

--- a/src/main/java/no/finn/unleash/strategy/StrategyUtils.java
+++ b/src/main/java/no/finn/unleash/strategy/StrategyUtils.java
@@ -1,0 +1,55 @@
+package no.finn.unleash.strategy;
+
+public final class StrategyUtils {
+    private static final int ONE_HUNDRED = 100;
+
+    public static boolean isNotEmpty(final CharSequence cs) {
+        return !isEmpty(cs);
+    }
+
+    public static boolean isEmpty(final CharSequence cs) {
+        return cs == null || cs.length() == 0;
+    }
+
+    public static boolean isNumeric(final CharSequence cs) {
+        if (isEmpty(cs)) {
+            return false;
+        }
+        final int sz = cs.length();
+        for (int i = 0; i < sz; i++) {
+            if (Character.isDigit(cs.charAt(i)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Takes to string inputs concat them, produce a hashCode and return a normalized value between 0 and 100;
+     *
+     * @param identifier
+     * @param groupId
+     * @return
+     */
+    public static int getNormalizedNumber(String identifier, String groupId) {
+        int hashCode = Math.abs((groupId + ':' + identifier).hashCode());
+        return hashCode % ONE_HUNDRED + 1;
+    }
+
+    /**
+     * Takes a numeric string value and converts it to a integer between 0 and 100.
+     *
+     * returns 0 if the string is not numeric.
+     *
+     * @param percentage - A numeric string value
+     * @return a integer between 0 and 100
+     */
+    public static int getPercentage(String percentage) {
+        if (isNotEmpty(percentage) && isNumeric(percentage)) {
+            int p = Integer.parseInt(percentage);
+            return p;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/no/finn/unleash/strategy/UserWithIdStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/UserWithIdStrategy.java
@@ -1,0 +1,33 @@
+package no.finn.unleash.strategy;
+
+import java.util.Map;
+import java.util.Optional;
+
+import no.finn.unleash.UnleashContext;
+
+import static java.util.Arrays.asList;
+
+public final class UserWithIdStrategy implements Strategy {
+
+    protected static final String PARAM = "userIds";
+    private static final String STRATEGY_NAME = "userWithId";
+
+    @Override
+    public String getName() {
+        return STRATEGY_NAME;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {
+        return unleashContext.getUserId()
+                           .map(currentUserId -> Optional.ofNullable(parameters.get(PARAM))
+                                                         .map(userIdString -> asList(userIdString.split(",\\s?")))
+                                                         .filter(f -> f.contains(currentUserId)).isPresent())
+                           .orElse(false);
+    }
+}

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -2,6 +2,7 @@ package no.finn.unleash.util;
 
 import java.io.File;
 import java.net.URI;
+import no.finn.unleash.UnleashContextProvider;
 
 public class UnleashConfig {
     private final URI unleashAPI;
@@ -12,6 +13,7 @@ public class UnleashConfig {
     private final long fetchTogglesInterval;
     private final long sendMetricsInterval;
     private final boolean disableMetrics;
+    private final UnleashContextProvider contextProvider;
 
     public UnleashConfig(
             URI unleashAPI,
@@ -20,7 +22,9 @@ public class UnleashConfig {
             String backupFile,
             long fetchTogglesInterval,
             long sendMetricsInterval,
-            boolean disableMetrics) {
+            boolean disableMetrics,
+            UnleashContextProvider contextProvider) {
+
 
         if(appName == null) {
             throw new IllegalStateException("You are required to specify the unleash appName");
@@ -38,6 +42,7 @@ public class UnleashConfig {
         this.fetchTogglesInterval = fetchTogglesInterval;
         this.sendMetricsInterval = sendMetricsInterval;
         this.disableMetrics = disableMetrics;
+        this.contextProvider = contextProvider;
     }
 
     public URI getUnleashAPI() {
@@ -76,6 +81,10 @@ public class UnleashConfig {
         return this.backupFile;
     }
 
+    public UnleashContextProvider getContextProvider() {
+        return contextProvider;
+    }
+
     public static class Builder {
         private URI unleashAPI;
         private String appName;
@@ -84,6 +93,7 @@ public class UnleashConfig {
         private long fetchTogglesInterval = 10;
         private long sendMetricsInterval = 60;
         private boolean disableMetrics = false;
+        private UnleashContextProvider contextProvider = UnleashContextProvider.getDefaultProvider();
 
 
         public Builder unleashAPI(URI unleashAPI) {
@@ -126,6 +136,11 @@ public class UnleashConfig {
             return this;
         }
 
+        public Builder unleashContextProvider(UnleashContextProvider contextProvider) {
+            this.contextProvider = contextProvider;
+            return this;
+        }
+
         private String getBackupFile() {
             if(backupFile != null) {
                 return backupFile;
@@ -143,7 +158,8 @@ public class UnleashConfig {
                     getBackupFile(),
                     fetchTogglesInterval,
                     sendMetricsInterval,
-                    disableMetrics);
+                    disableMetrics,
+                    contextProvider);
         }
     }
 }

--- a/src/test/java/no/finn/unleash/ManualTesting.java
+++ b/src/test/java/no/finn/unleash/ManualTesting.java
@@ -23,9 +23,14 @@ public class ManualTesting {
         UnleashConfig unleashConfig = new UnleashConfig.Builder()
                 .appName("java-test")
                 .instanceId("instance y")
-                .unleashAPI("https://unleash-new-ui.herokuapp.com/api/")
+                .unleashAPI("https://unleash.herokuapp.com/api/")
                 .fetchTogglesInterval(1)
-                .sendMetricsInterval(10)
+                .sendMetricsInterval(2)
+                .unleashContextProvider(() -> UnleashContext.builder()
+                        .sessionId(new Random().nextInt(10000) + "")
+                        .userId(new Random().nextInt(10000) + "")
+                        .remoteAddress("192.168.1.1")
+                        .build())
                 .build();
 
         Unleash unleash = new DefaultUnleash(unleashConfig, strategy);
@@ -52,6 +57,7 @@ public class ManualTesting {
             while(currentRound < maxRounds) {
                 currentRound++;
                 long startTime = System.nanoTime();
+
                 boolean enabled = unleash.isEnabled("Demo");
                 long timeUsed = System.nanoTime() - startTime;
 

--- a/src/test/java/no/finn/unleash/strategy/ApplicationHostnameStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/ApplicationHostnameStrategyTest.java
@@ -87,6 +87,18 @@ public class ApplicationHostnameStrategyTest {
     }
 
     @Test
+    public void should_be_enabled_for_dashed_host() throws UnknownHostException {
+        String hostName  = "super-wiEred-host";
+        System.setProperty("hostname", hostName);
+
+        Strategy strategy = new ApplicationHostnameStrategy();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("hostNames", "MegaHost," + hostName + ",MiniHost, happyHost");
+        assertTrue(strategy.isEnabled(params));
+    }
+
+    @Test
     public void null_test(){
         Strategy strategy = new ApplicationHostnameStrategy();
         assertFalse(strategy.isEnabled(new HashMap<>()));

--- a/src/test/java/no/finn/unleash/strategy/ApplicationHostnameStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/ApplicationHostnameStrategyTest.java
@@ -1,0 +1,95 @@
+package no.finn.unleash.strategy;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ApplicationHostnameStrategyTest {
+
+    @After
+    public void remove_hostname_property() {
+        System.getProperties().remove("hostname");
+    }
+
+    @Test
+    public void should_be_disabled_if_no_HostNames_in_params() {
+        Strategy strategy = new ApplicationHostnameStrategy();
+        Map<String, String> params = new HashMap<>();
+        params.put("hostNames", null);
+
+        assertFalse(strategy.isEnabled(params));
+    }
+
+    @Test
+    public void should_be_disabled_if_hostname_not_in_list() {
+        Strategy strategy = new ApplicationHostnameStrategy();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("hostNames", "MegaHost,MiniHost, happyHost");
+
+        assertFalse(strategy.isEnabled(params));
+    }
+
+    @Test
+    public void should_be_enabled_for_hostName(){
+        String hostName  = "my-super-host";
+        System.setProperty("hostname", hostName);
+
+        Strategy strategy = new ApplicationHostnameStrategy();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("hostNames", "MegaHost," + hostName + ",MiniHost, happyHost");
+        assertTrue(strategy.isEnabled(params));
+    }
+
+    @Test
+    public void should_handle_weird_casing(){
+        String hostName  = "my-super-host";
+        System.setProperty("hostname", hostName);
+
+        Strategy strategy = new ApplicationHostnameStrategy();
+
+        Map<String, String> params = new HashMap<>();
+
+        params.put("hostNames", "MegaHost," + hostName.toUpperCase() + ",MiniHost, happyHost");
+        assertTrue(strategy.isEnabled(params));
+    }
+
+    @Test
+    public void so_close_but_no_cigar(){
+        String hostName  = "my-super-host";
+        System.setProperty("hostname", hostName);
+
+        Strategy strategy = new ApplicationHostnameStrategy();
+
+        Map<String, String> params = new HashMap<>();
+
+        params.put("hostNames", "MegaHost, MiniHost, SuperhostOne");
+        assertFalse(strategy.isEnabled(params));
+    }
+
+    @Test
+    public void should_be_enabled_for_InetAddress() throws UnknownHostException {
+        String hostName  = InetAddress.getLocalHost().getHostName();
+        System.setProperty("hostname", hostName);
+
+        Strategy strategy = new ApplicationHostnameStrategy();
+
+        Map<String, String> params = new HashMap<>();
+        params.put("hostNames", "MegaHost," + hostName + ",MiniHost, happyHost");
+        assertTrue(strategy.isEnabled(params));
+    }
+
+    @Test
+    public void null_test(){
+        Strategy strategy = new ApplicationHostnameStrategy();
+        assertFalse(strategy.isEnabled(new HashMap<>()));
+    }
+
+}

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
@@ -74,15 +74,18 @@ public final class GradualRolloutRandomStrategyTest {
 
         for (int i = 0; i <= 100; i++) {
             final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
-            assertTrue("Should be enabled for p="+i, enabled);
+            assertTrue("Should be enabled for p=" + i, enabled);
         }
     }
 
-    @Ignore
     @Test
-    public void localTest() {
+    public void should_diverage_at_most_with_one_percent_point() {
+        int percentage = 55;
+        final int min= percentage - 1;
+        final int max = percentage + 1;
+
         final Map<String, String> parameters = new HashMap<String, String>() {{
-            put("percentage", "55");
+            put("percentage", ""+percentage);
         }};
 
         int rounds = 20000;
@@ -94,7 +97,10 @@ public final class GradualRolloutRandomStrategyTest {
                 countEnabled = countEnabled + 1;
             }
         }
-        
-        System.out.println("Percentage: " + ((double)countEnabled / rounds));
+
+        long measuredPercentage = Math.round(((double) countEnabled / rounds * 100));
+
+        assertTrue(measuredPercentage >= min);
+        assertTrue(measuredPercentage <= max);
     }
 }

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
@@ -72,7 +72,7 @@ public final class GradualRolloutRandomStrategyTest {
             put("percentage", "100");
         }};
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i <= 100; i++) {
             final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
             assertTrue("Should be enabled for p="+i, enabled);
         }

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Random;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -44,7 +45,7 @@ public final class GradualRolloutRandomStrategyTest {
     @Test
     public void should_not_be_enabled_when_percentage_is_not_a_not_a_valid_percentage_value() {
         final Map<String, String> parameters = new HashMap<String, String>() {{
-            put("percentage", "09");
+            put("percentage", "ab");
         }};
 
         final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
@@ -73,8 +74,27 @@ public final class GradualRolloutRandomStrategyTest {
 
         for (int i = 0; i < 1000; i++) {
             final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
-            assertTrue(enabled);
+            assertTrue("Should be enabled for p="+i, enabled);
         }
+    }
 
+    @Ignore
+    @Test
+    public void localTest() {
+        final Map<String, String> parameters = new HashMap<String, String>() {{
+            put("percentage", "55");
+        }};
+
+        int rounds = 20000;
+        int countEnabled = 0;
+
+        for (int i = 0; i < rounds; i++) {
+            final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
+            if(enabled) {
+                countEnabled = countEnabled + 1;
+            }
+        }
+        
+        System.out.println("Percentage: " + ((double)countEnabled / rounds));
     }
 }

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutRandomStrategyTest.java
@@ -1,0 +1,80 @@
+package no.finn.unleash.strategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class GradualRolloutRandomStrategyTest {
+
+    private static GradualRolloutRandomStrategy gradualRolloutRandomStrategy;
+
+    @Before
+    public void setUp() {
+        long seed = new Random().nextLong();
+        System.out.println("GradualRolloutRandomStrategyTest running with seed: " + seed);
+        gradualRolloutRandomStrategy = new GradualRolloutRandomStrategy(seed);
+    }
+
+    @Test
+    public void should_not_be_enabled_when_percentage_not_set() {
+        final Map<String, String> parameters = new HashMap<>();
+
+        final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
+
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void should_not_be_enabled_when_percentage_is_not_a_not_a_number() {
+        final Map<String, String> parameters = new HashMap<String, String>() {{
+            put("percentage", "foo");
+        }};
+
+        final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
+
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void should_not_be_enabled_when_percentage_is_not_a_not_a_valid_percentage_value() {
+        final Map<String, String> parameters = new HashMap<String, String>() {{
+            put("percentage", "09");
+        }};
+
+        final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
+
+        assertFalse(enabled);
+    }
+
+    @Test
+    public void should_never_be_enabled_when_0_percent() {
+        final Map<String, String> parameters = new HashMap<String, String>() {{
+            put("percentage", "0");
+        }};
+
+        for (int i = 0; i < 1000; i++) {
+            final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
+            assertFalse(enabled);
+        }
+
+    }
+
+    @Test
+    public void should_always_be_enabled_when_100_percent() {
+        final Map<String, String> parameters = new HashMap<String, String>() {{
+            put("percentage", "100");
+        }};
+
+        for (int i = 0; i < 1000; i++) {
+            final boolean enabled = gradualRolloutRandomStrategy.isEnabled(parameters);
+            assertTrue(enabled);
+        }
+
+    }
+}

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategyTest.java
@@ -1,0 +1,168 @@
+package no.finn.unleash.strategy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import com.google.common.collect.ImmutableList;
+import no.finn.unleash.UnleashContext;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class GradualRolloutSessionIdStrategyTest {
+    private static final long SEED = 89235015401L;
+    private static final long MIN = 10000000L;
+    private static final long MAX = 9999999999L;
+
+    Random rand = new Random(SEED);
+    List<Integer> percentages;
+
+    @Before
+    public void init() {
+        percentages = ImmutableList.<Integer>builder()
+                .add(1)
+                .add(2)
+                .add(5)
+                .add(10)
+                .add(25)
+                .add(50)
+                .add(90)
+                .add(99)
+                .add(100)
+                .build();
+    }
+
+    @Test
+    public void should_have_a_name() {
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+        assertThat(gradualRolloutStrategy.getName(), is("gradualRolloutSessionId"));
+    }
+
+    @Test
+    public void should_require_context() {
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>()), is(false));
+    }
+
+    @Test
+    public void should_be_disabled_when_missing_user_id() {
+        UnleashContext context = UnleashContext.builder().build();
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>(), context), is(false));
+    }
+
+    @Test
+    public void should_have_same_result_for_multiple_executions() {
+        UnleashContext context = UnleashContext.builder().sessionId("1574576830").build();
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+
+        Map<String, String> params = buildParams(1, "innfinn");
+        boolean firstRunResult = gradualRolloutStrategy.isEnabled(params, context);
+
+        for (int i = 0; i < 10; i++) {
+            boolean subsequentRunResult = gradualRolloutStrategy.isEnabled(params, context);
+            assertThat(
+                    "loginId will return same result when unchanged parameters",
+                    firstRunResult,
+                    is(equalTo(subsequentRunResult))
+            );
+        }
+    }
+
+    @Test
+    public void should_be_enabled_when_using_100percent_rollout() {
+        UnleashContext context = UnleashContext.builder().sessionId("1574576830").build();
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+
+        Map<String, String> params = buildParams(100, "innfinn");
+        boolean result = gradualRolloutStrategy.isEnabled(params, context);
+
+        assertThat(result, is(true));
+    }
+
+
+    @Test
+    public void should_not_be_enabled_when_0percent_rollout() {
+        UnleashContext context = UnleashContext.builder().sessionId("1574576830").build();
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+
+        Map<String, String> params = buildParams(0, "innfinn");
+        boolean actual = gradualRolloutStrategy.isEnabled(params, context);
+
+        assertFalse("should not be enabled when 0% rollout", actual);
+    }
+
+    @Test
+    public void should_be_enabled_above_minimum_percentage() {
+        String sessionId = "1574576830";
+        String groupId = "";
+        int minimumPercentage = StrategyUtils.getNormalizedNumber(sessionId, groupId);
+
+        UnleashContext context = UnleashContext.builder().sessionId(sessionId).build();
+
+        GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+
+        for(int p = minimumPercentage ; p <=100 ; p++) {
+            Map<String, String> params = buildParams(p, groupId);
+            boolean actual = gradualRolloutStrategy.isEnabled(params, context);
+            assertTrue("should be enabled when " + p + "% rollout", actual);
+        }
+    }
+
+
+    @Ignore // Intended for manual execution
+    @Test
+    public void generateReportForListOfLoginIDs() {
+        final int numberOfIDs = 200000;
+
+        for (Integer percentage : percentages) {
+            int numberOfEnabledUsers = checkRandomLoginIDs(numberOfIDs, percentage);
+            double p = ((double) numberOfEnabledUsers / (double) numberOfIDs) * 100.0;
+            System.out.println("Testing " + percentage + "% --> " + numberOfEnabledUsers + " of " + numberOfIDs + " got new feature (" + p + "%)");
+        }
+    }
+
+
+    protected int checkRandomLoginIDs(int numberOfIDs, int percentage) {
+        int numberOfEnabledUsers = 0;
+        for (int i = 0; i < numberOfIDs; i++) {
+            Long sessionId = getRandomLoginId();
+            UnleashContext context = UnleashContext.builder().sessionId(sessionId.toString()).build();
+
+            GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
+
+            Map<String, String> params = buildParams(percentage, "");
+            boolean enabled = gradualRolloutStrategy.isEnabled(params, context);
+            if (enabled) {
+                numberOfEnabledUsers++;
+            }
+        }
+        return numberOfEnabledUsers;
+    }
+
+    private Map<String, String> buildParams(int percentage, String groupId) {
+        Map<String, String> params = new HashMap();
+        params.put(GradualRolloutSessionIdStrategy.PERCENTAGE, String.valueOf(percentage));
+        params.put(GradualRolloutSessionIdStrategy.GROUP_ID, groupId);
+
+        return params;
+    }
+
+
+    private Long getRandomLoginId() {
+        long bits, val;
+        long bound = (MAX - MIN) + 1L;
+        do {
+            bits = (rand.nextLong() << 1) >>> 1;
+            val = bits % bound;
+        } while (bits - val + (bound - 1L) < 0L);
+        return val;
+    }
+}

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategyTest.java
@@ -116,6 +116,35 @@ public class GradualRolloutUserIdStrategyTest {
         }
     }
 
+    @Test
+    public void should_at_most_miss_with_one_percent_when_rolling_out_to_specified_percentage() {
+        String groupId = "group1";
+        int percentage = 25;
+        int rounds = 20000;
+        int enabledCount = 0;
+
+        Map<String, String> params = buildParams(percentage, groupId);
+
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+
+        for(int userId=0; userId < rounds; userId++) {
+            UnleashContext context = UnleashContext.builder().userId("user"+ userId).build();
+
+            if(gradualRolloutStrategy.isEnabled(params, context)) {
+                enabledCount++;
+            }
+        }
+
+        double actualPercentage = ((double) enabledCount / (double) rounds) * 100.0;
+
+        assertTrue("Expected " + percentage + "%, but was "+ actualPercentage + "%" ,
+                (percentage-1) < actualPercentage);
+
+        assertTrue("Expected " + percentage + "%, but was "+ actualPercentage + "%" ,
+                (percentage+1) > actualPercentage);
+    }
+
 
     @Ignore // Intended for manual execution
     @Test

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategyTest.java
@@ -1,0 +1,168 @@
+package no.finn.unleash.strategy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import com.google.common.collect.ImmutableList;
+import no.finn.unleash.UnleashContext;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class GradualRolloutUserIdStrategyTest {
+    private static final long SEED = 89235015401L;
+    private static final long MIN = 10000000L;
+    private static final long MAX = 9999999999L;
+
+    Random rand = new Random(SEED);
+    List<Integer> percentages;
+
+    @Before
+    public void init() {
+        percentages = ImmutableList.<Integer>builder()
+                .add(1)
+                .add(2)
+                .add(5)
+                .add(10)
+                .add(25)
+                .add(50)
+                .add(90)
+                .add(99)
+                .add(100)
+                .build();
+    }
+
+    @Test
+    public void should_have_a_name() {
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+        assertThat(gradualRolloutStrategy.getName(), is("gradualRolloutUserId"));
+    }
+
+    @Test
+    public void should_require_context() {
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>()), is(false));
+    }
+
+    @Test
+    public void should_be_disabled_when_missing_user_id() {
+        UnleashContext context = UnleashContext.builder().build();
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>(), context), is(false));
+    }
+
+    @Test
+    public void should_have_same_result_for_multiple_executions() {
+        UnleashContext context = UnleashContext.builder().userId("1574576830").build();
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+        Map<String, String> params = buildParams(1, "innfinn");
+        boolean firstRunResult = gradualRolloutStrategy.isEnabled(params, context);
+
+        for (int i = 0; i < 10; i++) {
+            boolean subsequentRunResult = gradualRolloutStrategy.isEnabled(params, context);
+            assertThat(
+                    "loginId will return same result when unchanged parameters",
+                    firstRunResult,
+                    is(equalTo(subsequentRunResult))
+            );
+        }
+    }
+
+    @Test
+    public void should_be_enabled_when_using_100percent_rollout() {
+        UnleashContext context = UnleashContext.builder().userId("1574576830").build();
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+        Map<String, String> params = buildParams(100, "innfinn");
+        boolean result = gradualRolloutStrategy.isEnabled(params, context);
+
+        assertThat(result, is(true));
+    }
+
+
+    @Test
+    public void should_not_be_enabled_when_0percent_rollout() {
+        UnleashContext context = UnleashContext.builder().userId("1574576830").build();
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+        Map<String, String> params = buildParams(0, "innfinn");
+        boolean actual = gradualRolloutStrategy.isEnabled(params, context);
+
+        assertFalse("should not be enabled when 0% rollout", actual);
+    }
+
+    @Test
+    public void should_be_enabled_above_minimum_percentage() {
+        String userId = "1574576830";
+        String groupId = "";
+        int minimumPercentage = StrategyUtils.getNormalizedNumber(userId, groupId);
+
+        UnleashContext context = UnleashContext.builder().userId(userId).build();
+
+        GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+        for(int p = minimumPercentage ; p <=100 ; p++) {
+            Map<String, String> params = buildParams(p, groupId);
+            boolean actual = gradualRolloutStrategy.isEnabled(params, context);
+            assertTrue("should be enabled when " + p + "% rollout", actual);
+        }
+    }
+
+
+    @Ignore // Intended for manual execution
+    @Test
+    public void generateReportForListOfLoginIDs() {
+        final int numberOfIDs = 200000;
+
+        for (Integer percentage : percentages) {
+            int numberOfEnabledUsers = checkRandomLoginIDs(numberOfIDs, percentage);
+            double p = ((double) numberOfEnabledUsers / (double) numberOfIDs) * 100.0;
+            System.out.println("Testing " + percentage + "% --> " + numberOfEnabledUsers + " of " + numberOfIDs + " got new feature (" + p + "%)");
+        }
+    }
+
+
+    protected int checkRandomLoginIDs(int numberOfIDs, int percentage) {
+        int numberOfEnabledUsers = 0;
+        for (int i = 0; i < numberOfIDs; i++) {
+            Long userId = getRandomLoginId();
+            UnleashContext context = UnleashContext.builder().userId(userId.toString()).build();
+
+            GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
+
+            Map<String, String> params = buildParams(percentage, "");
+            boolean enabled = gradualRolloutStrategy.isEnabled(params, context);
+            if (enabled) {
+                numberOfEnabledUsers++;
+            }
+        }
+        return numberOfEnabledUsers;
+    }
+
+    private Map<String, String> buildParams(int percentage, String groupId) {
+        Map<String, String> params = new HashMap();
+        params.put(GradualRolloutUserIdStrategy.PERCENTAGE, String.valueOf(percentage));
+        params.put(GradualRolloutUserIdStrategy.GROUP_ID, groupId);
+
+        return params;
+    }
+
+
+    private Long getRandomLoginId() {
+        long bits, val;
+        long bound = (MAX - MIN) + 1L;
+        do {
+            bits = (rand.nextLong() << 1) >>> 1;
+            val = bits % bound;
+        } while (bits - val + (bound - 1L) < 0L);
+        return val;
+    }
+}

--- a/src/test/java/no/finn/unleash/strategy/RemoteAddressStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/RemoteAddressStrategyTest.java
@@ -1,0 +1,76 @@
+package no.finn.unleash.strategy;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import no.finn.unleash.UnleashContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(Parameterized.class)
+public class RemoteAddressStrategyTest {
+    private static final String FIRST_IP = "127.0.0.1";
+    private static final String SECOND_IP = "10.0.0.1";
+    private static final String THIRD_IP = "196.0.0.1";
+    private static final List<String> ALL = Arrays.asList(FIRST_IP, SECOND_IP, THIRD_IP);
+
+    @Parameter(value=0)
+    public String actualIp;
+
+    @Parameter(value=1)
+    public String parameterString;
+
+    @Parameter(value=2)
+    public boolean expected;
+
+    private RemoteAddressStrategy strategy;
+
+    @Parameters(name="{index}: actualIp: {0}, parameter: {1}, expected: {2}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                {FIRST_IP, FIRST_IP, true},
+                {FIRST_IP, String.join(",", ALL), true},
+                {SECOND_IP, String.join(",", ALL), true},
+                {THIRD_IP, String.join(",", ALL), true},
+                {FIRST_IP, String.join(", ", ALL), true},
+                {SECOND_IP, String.join(", ", ALL), true},
+                {THIRD_IP, String.join(", ", ALL), true},
+                {SECOND_IP, String.join(",  ", ALL), true},
+                {SECOND_IP, String.join(".", ALL), false},
+                {FIRST_IP, SECOND_IP, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        strategy = new RemoteAddressStrategy();
+    }
+
+    @Test
+    public void should_have_a_name() {
+        assertThat(strategy.getName(), is("remoteAddress"));
+    }
+
+    @Test
+    public void test() {
+        UnleashContext context = UnleashContext.builder().remoteAddress(actualIp).build();
+        Map<String, String> parameters = setupParameterMap(parameterString);
+
+        assertThat(strategy.isEnabled(parameters, context), is(expected));
+    }
+
+    private Map<String, String> setupParameterMap(String ipString) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(RemoteAddressStrategy.PARAM, ipString);
+        return parameters;
+    }
+}

--- a/src/test/java/no/finn/unleash/strategy/StrategyUsingContext.java
+++ b/src/test/java/no/finn/unleash/strategy/StrategyUsingContext.java
@@ -1,0 +1,33 @@
+package no.finn.unleash.strategy;
+
+import java.util.List;
+import java.util.Map;
+import no.finn.unleash.UnleashContext;
+
+import static java.util.Arrays.asList;
+
+public class StrategyUsingContext implements Strategy {
+
+
+    @Override
+    public String getName() {
+        return "usingContext";
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {
+        String userIdString = parameters.get("userIds");
+        List<String> userIds = asList(userIdString.split(",\\s?"));
+        if(unleashContext.getUserId().isPresent()) {
+            String userId = unleashContext.getUserId().get();
+            return userIds.contains(userId);
+        } else {
+            return false;
+        }
+    }
+}

--- a/src/test/java/no/finn/unleash/strategy/StrategyWithContextTest.java
+++ b/src/test/java/no/finn/unleash/strategy/StrategyWithContextTest.java
@@ -1,0 +1,44 @@
+package no.finn.unleash.strategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import no.finn.unleash.UnleashContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StrategyWithContextTest {
+    private StrategyUsingContext strategy;
+
+    @Before
+    public void setup() {
+        strategy = new StrategyUsingContext();
+    }
+
+    @Test
+    public void should_be_enabled_for_known_user() {
+        //Params
+        Map<String, String> params = new HashMap<>();
+        params.put("userIds", "123");
+
+        //Context
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+
+        assertTrue(strategy.isEnabled(params, context));
+    }
+
+    @Test
+    public void should_not_enabled_for_unknown_user() {
+        //Params
+        Map<String, String> params = new HashMap<>();
+        params.put("userIds", "123");
+
+        //Context
+        UnleashContext context = UnleashContext.builder().userId("other").build();
+
+        assertFalse(strategy.isEnabled(params, context));
+    }
+
+}

--- a/src/test/java/no/finn/unleash/strategy/UserWithIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/UserWithIdStrategyTest.java
@@ -1,0 +1,119 @@
+package no.finn.unleash.strategy;
+
+import java.util.HashMap;
+import java.util.Map;
+import no.finn.unleash.UnleashContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class UserWithIdStrategyTest {
+    private UserWithIdStrategy strategy;
+
+    @Before
+    public void setup() {
+        strategy = new UserWithIdStrategy();
+    }
+
+    @Test
+    public void should_have_expected_strategy_name() {
+        assertThat(strategy.getName(), is("userWithId"));
+
+    }
+
+    @Test
+    public void should_match_one_userId() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+        parameters.put(strategy.PARAM, "123");
+
+        assertTrue(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_match_first_userId_in_list() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+        parameters.put(strategy.PARAM, "123, 122, 121");
+
+        assertTrue(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_match_middle_userId_in_list() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+        parameters.put(strategy.PARAM, "123, 122, 121");
+
+        assertTrue(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_match_last_userId_in_list() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+        parameters.put(strategy.PARAM, "123, 122, 121");
+
+        assertTrue(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_not_match_subparts_of_ids() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("12").build();
+        parameters.put(strategy.PARAM, "123, 122, 121, 212");
+
+        assertFalse(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_not_match_csv_without_space() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+        parameters.put(strategy.PARAM, "123,122,121");
+
+        assertTrue(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_match_real_ids() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("298261117").build();
+        parameters.put(strategy.PARAM,
+                "160118738, 1823311338, 1422637466, 2125981185, 298261117, 1829486714, 463568019, 271166598");
+
+        assertTrue(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_not_match_real_ids() {
+        Map<String, String> parameters = new HashMap<>();
+
+        UnleashContext context = UnleashContext.builder().userId("32667774").build();
+        parameters.put(strategy.PARAM,
+                "160118738, 1823311338, 1422637466, 2125981185, 298261117, 1829486714, 463568019, 271166598");
+
+        assertFalse(strategy.isEnabled(parameters, context));
+    }
+
+    @Test
+    public void should_not_be_enabled_without_id() {
+        Map<String, String> parameters = new HashMap<>();
+
+        parameters.put(strategy.PARAM, "160118738, 1823311338");
+
+        assertFalse(strategy.isEnabled(parameters));
+    }
+
+}


### PR DESCRIPTION
The idea is to simplify common strategies via a shared unelash context. The context should be possible to provide just in time, or via a request bound probider. 

**Just in time example:**

```java
UnleashContext context = UnleashContext.builder().userId("user@mail.com").build();
unleash.isEnabled("someToggle", unleashContext);
```
The main benefit of just in time is that it is more explicit. It is also makes it easier when ThreadLocal is not bound to the current request. 


**Provider example:**
```java
UnleashContextProvider provider = new CustomUnleashContextProvider();
UnleashConfig config = UnleashConfig.builder().contextProvider(provider);
Unleash unleash = new DefaultUnleash(config):

// context will be provided to the strategy impl via the provided contextProvider. 
unleash.isEnabled("someToggle");
```


this is still WIP!

todo:

- [x] Implement UserContext
- [x] Implement common strategies: 
  - [x] UserWithIdStrategy
  - [x] GradualRolloutRandom Strategy
  - [x] GradualRolloutUserWithId Strategy
  - [x] GradualRolloutSessionId Strategy
  - [x] RemoteAddress Strategy
  - [x] ApplicationHostname Strategy
- [x] Add support for providing unleashContext (via config and inside UnleashDefault)
- [x] Unleash should add all "default" strategies automatically. 
- [x] Write some documentation on how to provide the UnleashContext ("just in time" vs provider)
- [x] Do some testing before merging.

