### PR TITLE
Add support for custom HTTP headers in API calls

### DIFF
--- a/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
+++ b/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
@@ -75,8 +75,7 @@ public class UnleashMetricsSender {
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("UNLEASH-APPNAME", this.unleashConfig.getAppName());
-            connection.setRequestProperty("UNLEASH-INSTANCEID", this.unleashConfig.getInstanceId());
+            UnleashConfig.setRequestProperties(connection, this.unleashConfig);
             connection.setUseCaches (false);
             connection.setDoInput(true);
             connection.setDoOutput(true);

--- a/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
+++ b/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
@@ -31,9 +31,7 @@ public final class HttpToggleFetcher implements ToggleFetcher {
             connection.setReadTimeout(CONNECT_TIMEOUT);
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("UNLEASH-APPNAME", this.unleashConfig.getAppName());
-            connection.setRequestProperty("UNLEASH-INSTANCEID", this.unleashConfig.getInstanceId());
-
+            UnleashConfig.setRequestProperties(connection, this.unleashConfig);
             connection.setRequestProperty("If-None-Match", etag);
             connection.setUseCaches(true);
             connection.connect();

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -11,8 +11,8 @@ import java.util.Map;
 import no.finn.unleash.UnleashContextProvider;
 
 public class UnleashConfig {
-    protected static final String UNLEASH_APP_NAME_HEADER = "UNLEASH-APPNAME";
-    protected static final String UNLEASH_INSTANCE_ID_HEADER = "UNLEASH-INSTANCEID";
+    static final String UNLEASH_APP_NAME_HEADER = "UNLEASH-APPNAME";
+    static final String UNLEASH_INSTANCE_ID_HEADER = "UNLEASH-INSTANCEID";
 
     private final URI unleashAPI;
     private final UnleashURLs unleashURLs;
@@ -104,9 +104,10 @@ public class UnleashConfig {
     public static void setRequestProperties(HttpURLConnection connection, UnleashConfig config) {
         connection.setRequestProperty(UNLEASH_APP_NAME_HEADER, config.getAppName());
         connection.setRequestProperty(UNLEASH_INSTANCE_ID_HEADER, config.getInstanceId());
-        for (String name : config.getCustomHttpHeaders().keySet()) {
-            connection.setRequestProperty(name, config.getCustomHttpHeaders().get(name));
-        }
+        connection.setRequestProperty("User-Agent", config.getAppName());
+        config.getCustomHttpHeaders().forEach((name, value) -> {
+            connection.setRequestProperty(name, value);
+        });
     }
 
     public static class Builder {

--- a/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
@@ -65,7 +65,7 @@ public class UnleashConfigTest {
     }
 
     @Test
-    public void should_add_app_name_and_instance_id_to_connection() throws IOException {
+    public void should_add_app_name_and_instance_id_and_user_agent_to_connection() throws IOException {
         String appName = "my-app";
         String instanceId = "my-instance-1";
         String unleashAPI = "http://unleash.org";
@@ -82,6 +82,7 @@ public class UnleashConfigTest {
         UnleashConfig.setRequestProperties(connection, unleashConfig);
         assertThat(connection.getRequestProperty(UNLEASH_APP_NAME_HEADER), is(appName));
         assertThat(connection.getRequestProperty(UNLEASH_INSTANCE_ID_HEADER), is(instanceId));
+        assertThat(connection.getRequestProperty("User-Agent"), is(appName));
     }
 
     @Test

--- a/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
@@ -1,9 +1,13 @@
 package no.finn.unleash.util;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
 import org.junit.Test;
 
-import java.net.URI;
-
+import static no.finn.unleash.util.UnleashConfig.UNLEASH_APP_NAME_HEADER;
+import static no.finn.unleash.util.UnleashConfig.UNLEASH_INSTANCE_ID_HEADER;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -58,5 +62,45 @@ public class UnleashConfigTest {
 
         assertThat(config.getAppName(), is("my-app"));
         assertThat(config.getBackupFile(), is("/test/unleash-backup.json"));
+    }
+
+    @Test
+    public void should_add_app_name_and_instance_id_to_connection() throws IOException {
+        String appName = "my-app";
+        String instanceId = "my-instance-1";
+        String unleashAPI = "http://unleash.org";
+
+        UnleashConfig unleashConfig = UnleashConfig.builder()
+                .appName(appName)
+                .instanceId(instanceId)
+                .unleashAPI(unleashAPI)
+                .build();
+
+        URL someUrl = new URL(unleashAPI + "/some/arbitrary/path");
+        HttpURLConnection connection = (HttpURLConnection) someUrl.openConnection();
+
+        UnleashConfig.setRequestProperties(connection, unleashConfig);
+        assertThat(connection.getRequestProperty(UNLEASH_APP_NAME_HEADER), is(appName));
+        assertThat(connection.getRequestProperty(UNLEASH_INSTANCE_ID_HEADER), is(instanceId));
+    }
+
+    @Test
+    public void should_add_custom_headers_to_connection_if_present() throws IOException {
+        String unleashAPI = "http://unleash.org";
+        String headerName = "UNLEASH-CUSTOM-TEST-HEADER";
+        String headerValue = "Some value";
+
+        UnleashConfig unleashConfig = UnleashConfig.builder()
+                .appName("my-app")
+                .instanceId("my-instance-1")
+                .unleashAPI(unleashAPI)
+                .customHttpHeader(headerName, headerValue)
+                .build();
+
+        URL someUrl = new URL(unleashAPI + "/some/arbitrary/path");
+        HttpURLConnection connection = (HttpURLConnection) someUrl.openConnection();
+
+        UnleashConfig.setRequestProperties(connection, unleashConfig);
+        assertThat(connection.getRequestProperty(headerName), is(headerValue));
     }
 }


### PR DESCRIPTION
This commit adds a map of custom HTTP headers to UnleashConfig, and
includes these headers in calls to the Unleash server. This may be used
to, e.g., add an `Authorization` field if the server is behind a wrapper
or proxy which requires authentication.

See Unleash/unleash#222 on GitHub for background discussion.