### PR TITLE
LogManager.getLogger() fails runtime with JDK11

### DIFF
--- a/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
+++ b/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
@@ -18,7 +18,7 @@ import java.time.ZoneOffset;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 public class UnleashMetricsSender {
-    private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger(UnleashMetricsSender.class);
     private static final int CONNECT_TIMEOUT = 1000;
 
     private final Gson gson;

--- a/src/main/java/no/finn/unleash/repository/FeatureToggleRepository.java
+++ b/src/main/java/no/finn/unleash/repository/FeatureToggleRepository.java
@@ -12,7 +12,7 @@ import no.finn.unleash.FeatureToggle;
 import no.finn.unleash.UnleashException;
 
 public final class FeatureToggleRepository implements ToggleRepository {
-    private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger(FeatureToggleRepository.class);
 
     private final ToggleBackupHandler toggleBackupHandler;
     private final ToggleFetcher toggleFetcher;

--- a/src/main/java/no/finn/unleash/repository/ToggleBackupHandlerFile.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleBackupHandlerFile.java
@@ -11,7 +11,7 @@ import java.util.List;
 import com.google.gson.JsonParseException;
 
 public class ToggleBackupHandlerFile implements ToggleBackupHandler {
-    private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger(ToggleBackupHandlerFile.class);
     private final String backupFile;
 
     public ToggleBackupHandlerFile(UnleashConfig config){

--- a/src/main/java/no/finn/unleash/util/UnleashScheduledExecutorImpl.java
+++ b/src/main/java/no/finn/unleash/util/UnleashScheduledExecutorImpl.java
@@ -6,7 +6,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.concurrent.*;
 
 public class UnleashScheduledExecutorImpl implements UnleashScheduledExecutor {
-    private static final Logger LOG = LogManager.getLogger();
+    private static final Logger LOG = LogManager.getLogger(UnleashScheduledExecutorImpl.class);
 
     private final ScheduledThreadPoolExecutor timer;
 


### PR DESCRIPTION
I cannot use unleash with JDK11 without this change.  So a new release would be nice as well :)

Ref:

Caused by: java.lang.UnsupportedOperationException: No class provided, and an appropriate one cannot be found.
	at org.apache.logging.log4j.LogManager.callerClass(LogManager.java:555) ~[log4j-api-2.11.1.jar!/:2.11.1]
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:580) ~[log4j-api-2.11.1.jar!/:2.11.1]
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:567) ~[log4j-api-2.11.1.jar!/:2.11.1]
	at no.finn.unleash.util.UnleashScheduledExecutorImpl.<clinit>(UnleashScheduledExecutorImpl.java:9) ~[unleash-client-java-3.1.1.jar!/:3.1.1]
	at no.finn.unleash.DefaultUnleash.<clinit>(DefaultUnleash.java:38) ~[unleash-client-java-3.1.1.jar!/:3.1.1]