### PR TITLE
feat: subscriber api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.11.1</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/no/finn/unleash/UnleashException.java
+++ b/src/main/java/no/finn/unleash/UnleashException.java
@@ -1,8 +1,17 @@
 package no.finn.unleash;
 
-public class UnleashException extends RuntimeException {
+import no.finn.unleash.event.UnleashEvent;
+import no.finn.unleash.event.UnleashSubscriber;
+
+public class UnleashException extends RuntimeException implements UnleashEvent {
 
     public UnleashException(String message, Throwable cause) {
         super(message, cause);
     }
+
+    @Override
+    public void publishTo(UnleashSubscriber unleashSubscriber) {
+        unleashSubscriber.onError(this);
+    }
+
 }

--- a/src/main/java/no/finn/unleash/event/EventDispatcher.java
+++ b/src/main/java/no/finn/unleash/event/EventDispatcher.java
@@ -1,0 +1,23 @@
+package no.finn.unleash.event;
+
+import no.finn.unleash.util.UnleashConfig;
+import no.finn.unleash.util.UnleashScheduledExecutor;
+
+public class EventDispatcher {
+
+    private final UnleashSubscriber unleashSubscriber;
+    private final UnleashScheduledExecutor unleashScheduledExecutor;
+
+    public EventDispatcher(UnleashConfig unleashConfig) {
+        this.unleashSubscriber = unleashConfig.getSubscriber();
+        this.unleashScheduledExecutor = unleashConfig.getScheduledExecutor();
+    }
+
+    public void dispatch(UnleashEvent unleashEvent) {
+        unleashScheduledExecutor.scheduleOnce(() -> {
+            unleashSubscriber.on(unleashEvent);
+            unleashEvent.publishTo(unleashSubscriber);
+        });
+    }
+
+}

--- a/src/main/java/no/finn/unleash/event/Log4JSubscriber.java
+++ b/src/main/java/no/finn/unleash/event/Log4JSubscriber.java
@@ -1,0 +1,35 @@
+package no.finn.unleash.event;
+
+import no.finn.unleash.UnleashException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Log4JSubscriber implements UnleashSubscriber {
+
+    private static final Logger LOG = LogManager.getLogger(Log4JSubscriber.class);
+
+    private Level eventLevel = Level.INFO;
+    private Level errorLevel = Level.WARN;
+
+    @Override
+    public void on(UnleashEvent unleashEvent) {
+        LOG.log(eventLevel, unleashEvent.toString());
+    }
+
+    @Override
+    public void onError(UnleashException unleashException) {
+        LOG.log(errorLevel, unleashException.getMessage(), unleashException);
+    }
+
+    public Log4JSubscriber setEventLevel(Level eventLevel) {
+        this.eventLevel = eventLevel;
+        return this;
+    }
+
+    public Log4JSubscriber setErrorLevel(Level errorLevel) {
+        this.errorLevel = errorLevel;
+        return this;
+    }
+
+}

--- a/src/main/java/no/finn/unleash/event/NoOpSubscriber.java
+++ b/src/main/java/no/finn/unleash/event/NoOpSubscriber.java
@@ -1,0 +1,3 @@
+package no.finn.unleash.event;
+
+public class NoOpSubscriber implements UnleashSubscriber { }

--- a/src/main/java/no/finn/unleash/event/ToggleEvaluated.java
+++ b/src/main/java/no/finn/unleash/event/ToggleEvaluated.java
@@ -1,0 +1,31 @@
+package no.finn.unleash.event;
+
+public class ToggleEvaluated implements UnleashEvent {
+
+    private final String toggleName;
+    private final boolean enabled;
+
+    public ToggleEvaluated(String toggleName, boolean enabled) {
+        this.toggleName = toggleName;
+        this.enabled = enabled;
+    }
+
+    public String getToggleName() {
+        return toggleName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public void publishTo(UnleashSubscriber unleashSubscriber) {
+        unleashSubscriber.toggleEvaluated(this);
+    }
+
+    @Override
+    public String toString() {
+        return "ToggleEvaluated: " + toggleName + "=" + enabled;
+    }
+
+}

--- a/src/main/java/no/finn/unleash/event/UnleashEvent.java
+++ b/src/main/java/no/finn/unleash/event/UnleashEvent.java
@@ -1,0 +1,7 @@
+package no.finn.unleash.event;
+
+public interface UnleashEvent {
+
+    void publishTo(UnleashSubscriber unleashSubscriber);
+
+}

--- a/src/main/java/no/finn/unleash/event/UnleashReady.java
+++ b/src/main/java/no/finn/unleash/event/UnleashReady.java
@@ -1,0 +1,10 @@
+package no.finn.unleash.event;
+
+public class UnleashReady implements UnleashEvent {
+
+    @Override
+    public void publishTo(UnleashSubscriber unleashSubscriber) {
+        unleashSubscriber.onReady(this);
+    }
+
+}

--- a/src/main/java/no/finn/unleash/event/UnleashSubscriber.java
+++ b/src/main/java/no/finn/unleash/event/UnleashSubscriber.java
@@ -1,0 +1,25 @@
+package no.finn.unleash.event;
+
+import no.finn.unleash.UnleashException;
+import no.finn.unleash.metric.ClientMetrics;
+import no.finn.unleash.metric.ClientRegistration;
+import no.finn.unleash.repository.FeatureToggleResponse;
+import no.finn.unleash.repository.ToggleCollection;
+import org.apache.logging.log4j.LogManager;
+
+public interface UnleashSubscriber {
+
+    default void onError(UnleashException unleashException) {
+        LogManager.getLogger(UnleashSubscriber.class).warn(unleashException.getMessage(), unleashException);
+    }
+
+    default void on(UnleashEvent unleashEvent) { }
+    default void onReady(UnleashReady unleashReady) { }
+    default void toggleEvaluated(ToggleEvaluated toggleEvaluated) { }
+    default void togglesFetched(FeatureToggleResponse toggleResponse) { }
+    default void clientMetrics(ClientMetrics clientMetrics) { }
+    default void clientRegistered(ClientRegistration clientRegistration) { }
+    default void togglesBackedUp(ToggleCollection toggleCollection) { }
+    default void toggleBackupRestored(ToggleCollection toggleCollection) { }
+
+}

--- a/src/main/java/no/finn/unleash/metric/ClientMetrics.java
+++ b/src/main/java/no/finn/unleash/metric/ClientMetrics.java
@@ -1,8 +1,10 @@
 package no.finn.unleash.metric;
 
+import no.finn.unleash.event.UnleashEvent;
+import no.finn.unleash.event.UnleashSubscriber;
 import no.finn.unleash.util.UnleashConfig;
 
-class ClientMetrics {
+public class ClientMetrics implements UnleashEvent {
 
     private final String appName;
     private final String instanceId;
@@ -25,4 +27,18 @@ class ClientMetrics {
     public MetricsBucket getBucket() {
         return bucket;
     }
+
+    @Override
+    public void publishTo(UnleashSubscriber unleashSubscriber) {
+        unleashSubscriber.clientMetrics(this);
+    }
+
+    @Override
+    public String toString() {
+        return "metrics:"
+                + " appName=" + appName
+                + " instanceId=" + instanceId
+                ;
+    }
+
 }

--- a/src/main/java/no/finn/unleash/metric/ClientRegistration.java
+++ b/src/main/java/no/finn/unleash/metric/ClientRegistration.java
@@ -1,11 +1,13 @@
  package no.finn.unleash.metric;
 
+ import no.finn.unleash.event.UnleashEvent;
+ import no.finn.unleash.event.UnleashSubscriber;
  import no.finn.unleash.util.UnleashConfig;
 
  import java.time.LocalDateTime;
  import java.util.Set;
 
-class ClientRegistration {
+public class ClientRegistration implements UnleashEvent {
     private final String appName;
     private final String instanceId;
     private final String sdkVersion;
@@ -44,5 +46,22 @@ class ClientRegistration {
 
     public long getInterval() {
         return interval;
+    }
+
+    @Override
+    public void publishTo(UnleashSubscriber unleashSubscriber) {
+        unleashSubscriber.clientRegistered(this);
+    }
+
+    @Override
+    public String toString() {
+        return "client registration:"
+                + " appName=" + appName
+                + " instanceId=" + instanceId
+                + " sdkVersion=" + sdkVersion
+                + " started=" + sdkVersion
+                + " interval=" + sdkVersion
+                + " strategies=" + strategies
+                ;
     }
 }

--- a/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
+++ b/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
@@ -2,6 +2,7 @@ package no.finn.unleash.metric;
 
 import com.google.gson.*;
 import no.finn.unleash.UnleashException;
+import no.finn.unleash.event.EventDispatcher;
 import no.finn.unleash.util.UnleashConfig;
 import no.finn.unleash.util.UnleashURLs;
 import org.apache.logging.log4j.LogManager;
@@ -18,16 +19,17 @@ import java.time.ZoneOffset;
 import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 public class UnleashMetricsSender {
-    private static final Logger LOG = LogManager.getLogger(UnleashMetricsSender.class);
     private static final int CONNECT_TIMEOUT = 1000;
 
     private final Gson gson;
+    private final EventDispatcher eventDispatcher;
     private UnleashConfig unleashConfig;
     private final URL clientRegistrationURL;
     private final URL clientMetricsURL;
 
     public UnleashMetricsSender(UnleashConfig unleashConfig) {
         this.unleashConfig = unleashConfig;
+        this.eventDispatcher = new EventDispatcher(unleashConfig);
         UnleashURLs urls =  unleashConfig.getUnleashURLs();
         this.clientMetricsURL = urls.getClientMetricsURL();
         this.clientRegistrationURL = urls.getClientRegisterURL();
@@ -49,8 +51,9 @@ public class UnleashMetricsSender {
         if(!unleashConfig.isDisableMetrics()) {
             try {
                 post(clientRegistrationURL, registration);
+                eventDispatcher.dispatch(registration);
             } catch(UnleashException ex) {
-                LOG.warn("failed to register client", ex);
+                eventDispatcher.dispatch(ex);
             }
         }
     }
@@ -59,8 +62,9 @@ public class UnleashMetricsSender {
         if(!unleashConfig.isDisableMetrics()) {
             try {
                 post(clientMetricsURL, metrics);
+                eventDispatcher.dispatch(metrics);
             } catch(UnleashException ex) {
-                LOG.warn("failed to send metrics", ex);
+                eventDispatcher.dispatch(ex);
             }
         }
     }
@@ -87,6 +91,7 @@ public class UnleashMetricsSender {
 
             connection.connect();
 
+            // TODO should probably check response code to detect errors?
             return connection.getResponseCode();
         } catch (IOException e) {
             throw new UnleashException("Could not post to Unleash API", e);

--- a/src/main/java/no/finn/unleash/repository/ToggleBackupHandlerFile.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleBackupHandlerFile.java
@@ -1,6 +1,10 @@
 package no.finn.unleash.repository;
 
 import no.finn.unleash.FeatureToggle;
+import no.finn.unleash.UnleashException;
+import no.finn.unleash.event.EventDispatcher;
+import no.finn.unleash.event.UnleashEvent;
+import no.finn.unleash.event.UnleashSubscriber;
 import no.finn.unleash.util.UnleashConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -12,10 +16,13 @@ import com.google.gson.JsonParseException;
 
 public class ToggleBackupHandlerFile implements ToggleBackupHandler {
     private static final Logger LOG = LogManager.getLogger(ToggleBackupHandlerFile.class);
+
     private final String backupFile;
+    private final EventDispatcher eventDispatcher;
 
     public ToggleBackupHandlerFile(UnleashConfig config){
         this.backupFile = config.getBackupFile();
+        this.eventDispatcher = new EventDispatcher(config);
     }
 
     @Override
@@ -23,12 +30,14 @@ public class ToggleBackupHandlerFile implements ToggleBackupHandler {
         LOG.info("Unleash will try to load feature toggle states from temporary backup");
         try (FileReader reader = new FileReader(backupFile)) {
             BufferedReader br = new BufferedReader(reader);
-            return JsonToggleParser.fromJson(br);
+            ToggleCollection toggleCollection = JsonToggleParser.fromJson(br);
+            eventDispatcher.dispatch(new ToggleBackupRead(toggleCollection));
+            return toggleCollection;
         } catch (FileNotFoundException e) {
             LOG.warn(" Unleash could not find the backup-file '" + backupFile + "'. \n" +
                     "This is expected behavior the first time unleash runs in a new environment.");
         } catch (IOException | IllegalStateException | JsonParseException e) {
-            LOG.warn("Failed to read backup file:'{}'", backupFile, e);
+            eventDispatcher.dispatch(new UnleashException("Failed to read backup file: " + backupFile, e));
         }
         List<FeatureToggle> emptyList = Collections.emptyList();
         return new ToggleCollection(emptyList);
@@ -38,8 +47,38 @@ public class ToggleBackupHandlerFile implements ToggleBackupHandler {
     public void write(ToggleCollection toggleCollection) {
         try (FileWriter writer = new FileWriter(backupFile)) {
             writer.write(JsonToggleParser.toJsonString(toggleCollection));
+            eventDispatcher.dispatch(new ToggleBackupWritten(toggleCollection));
         } catch (IOException e) {
-            LOG.warn("Unleash was unable to backup feature toggles to file: {}", backupFile, e);
+            eventDispatcher.dispatch(new UnleashException("Unleash was unable to backup feature toggles to file: " + backupFile, e));
         }
     }
+
+    private static class ToggleBackupRead implements UnleashEvent {
+
+        private final ToggleCollection toggleCollection;
+
+        private ToggleBackupRead(ToggleCollection toggleCollection) {
+            this.toggleCollection = toggleCollection;
+        }
+
+        @Override
+        public void publishTo(UnleashSubscriber unleashSubscriber) {
+            unleashSubscriber.toggleBackupRestored(toggleCollection);
+        }
+    }
+
+    private static class ToggleBackupWritten implements UnleashEvent {
+
+        private final ToggleCollection toggleCollection;
+
+        private ToggleBackupWritten(ToggleCollection toggleCollection) {
+            this.toggleCollection = toggleCollection;
+        }
+
+        @Override
+        public void publishTo(UnleashSubscriber unleashSubscriber) {
+            unleashSubscriber.togglesBackedUp(toggleCollection);
+        }
+    }
+
 }

--- a/src/main/java/no/finn/unleash/repository/ToggleCollection.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleCollection.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import no.finn.unleash.FeatureToggle;
 
-final class ToggleCollection {
+public final class ToggleCollection {
     private final Collection<FeatureToggle> features;
     private final int version = 1;
     private final transient Map<String, FeatureToggle> cache;

--- a/src/main/java/no/finn/unleash/util/UnleashScheduledExecutor.java
+++ b/src/main/java/no/finn/unleash/util/UnleashScheduledExecutor.java
@@ -5,4 +5,7 @@ import java.util.concurrent.*;
 public interface UnleashScheduledExecutor {
        ScheduledFuture setInterval(
                Runnable command, long initialDelaySec, long periodSec) throws RejectedExecutionException;
+
+       Future<Void> scheduleOnce(Runnable runnable);
+
 }

--- a/src/test/java/no/finn/unleash/SynchronousTestExecutor.java
+++ b/src/test/java/no/finn/unleash/SynchronousTestExecutor.java
@@ -1,0 +1,65 @@
+package no.finn.unleash;
+
+import no.finn.unleash.util.UnleashScheduledExecutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class SynchronousTestExecutor implements UnleashScheduledExecutor {
+
+    private static final Logger LOG = LogManager.getLogger(SynchronousTestExecutor.class);
+
+    @Override
+    public ScheduledFuture setInterval(Runnable command, long initialDelaySec, long periodSec) throws RejectedExecutionException {
+        LOG.warn("i will only do this once");
+        return scheduleOnce(command);
+    }
+
+    @Override
+    public ScheduledFuture scheduleOnce(Runnable runnable) {
+        runnable.run();
+        return new AlreadyCompletedScheduledFuture();
+    }
+
+    private static class AlreadyCompletedScheduledFuture implements ScheduledFuture<Void> {
+        @Override
+        public long getDelay(TimeUnit timeUnit) {
+            return 0;
+        }
+
+        @Override
+        public int compareTo(Delayed delayed) {
+            return 0;
+        }
+
+        @Override
+        public boolean cancel(boolean b) {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public Void get() {
+            return null;
+        }
+
+        @Override
+        public Void get(long l, TimeUnit timeUnit) {
+            return null;
+        }
+    }
+
+}

--- a/src/test/java/no/finn/unleash/event/SubscriberTest.java
+++ b/src/test/java/no/finn/unleash/event/SubscriberTest.java
@@ -1,0 +1,111 @@
+package no.finn.unleash.event;
+
+import com.github.jenspiegsa.mockitoextension.ConfigureWireMock;
+import com.github.jenspiegsa.mockitoextension.InjectServer;
+import com.github.jenspiegsa.mockitoextension.WireMockExtension;
+import com.github.jenspiegsa.mockitoextension.WireMockSettings;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.Options;
+import no.finn.unleash.DefaultUnleash;
+import no.finn.unleash.SynchronousTestExecutor;
+import no.finn.unleash.Unleash;
+import no.finn.unleash.UnleashException;
+import no.finn.unleash.repository.FeatureToggleResponse;
+import no.finn.unleash.util.UnleashConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static no.finn.unleash.repository.FeatureToggleResponse.Status.UNAVAILABLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ExtendWith(WireMockExtension.class)
+@WireMockSettings(failOnUnmatchedRequests = false)
+public class SubscriberTest {
+
+    @ConfigureWireMock
+    Options options = wireMockConfig().dynamicPort();
+
+    @InjectServer
+    WireMockServer serverMock;
+
+    private TestSubscriber testSubscriber = new TestSubscriber();
+    private UnleashConfig unleashConfig;
+
+    @BeforeEach
+    void setup() {
+        unleashConfig = new UnleashConfig.Builder()
+                .appName(SubscriberTest.class.getSimpleName())
+                .instanceId(SubscriberTest.class.getSimpleName())
+                .synchronousFetchOnInitialisation(true)
+                .unleashAPI("http://localhost:" + serverMock.port())
+                .subscriber(testSubscriber)
+                .scheduledExecutor(new SynchronousTestExecutor())
+                .build();
+    }
+
+    @Test
+    void subscriberAreNotified() {
+        Unleash unleash = new DefaultUnleash(unleashConfig);
+
+        unleash.isEnabled("myFeature");
+        unleash.isEnabled("myFeature");
+        unleash.isEnabled("myFeature");
+
+        assertThat(testSubscriber.togglesFetchedCounter).isEqualTo(2); // one forced, one scheduled
+        assertThat(testSubscriber.status).isEqualTo(UNAVAILABLE);
+        assertThat(testSubscriber.toggleEvalutatedCounter).isEqualTo(3);
+        assertThat(testSubscriber.toggleName).isEqualTo("myFeature");
+        assertThat(testSubscriber.toggleEnabled).isFalse();
+        assertThat(testSubscriber.errors).hasSize(2);
+
+        assertThat(testSubscriber.events).hasSize(3 // feature evaluations
+                + 2 // toggle fetches
+                + 1 // unleash ready
+                + 1 // client registration
+                + 1 // client metrics
+        );
+    }
+
+    private class TestSubscriber implements UnleashSubscriber {
+
+        private int togglesFetchedCounter;
+        private FeatureToggleResponse.Status status;
+
+        private int toggleEvalutatedCounter;
+        private String toggleName;
+        private boolean toggleEnabled;
+
+        private List<UnleashEvent> events = new ArrayList<>();
+        private List<UnleashException> errors = new ArrayList<>();
+
+        @Override
+        public void on(UnleashEvent unleashEvent) {
+            this.events.add(unleashEvent);
+        }
+
+        @Override
+        public void onError(UnleashException unleashException) {
+            this.errors.add(unleashException);
+        }
+
+        @Override
+        public void toggleEvaluated(ToggleEvaluated toggleEvaluated) {
+            this.toggleEvalutatedCounter++;
+            this.toggleName = toggleEvaluated.getToggleName();
+            this.toggleEnabled = toggleEvaluated.isEnabled();
+        }
+
+        @Override
+        public void togglesFetched(FeatureToggleResponse toggleResponse) {
+            this.togglesFetchedCounter++;
+            this.status = toggleResponse.getStatus();
+        }
+    }
+
+}

--- a/src/test/java/no/finn/unleash/util/UnleashScheduledExecutorImplTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashScheduledExecutorImplTest.java
@@ -1,0 +1,32 @@
+package no.finn.unleash.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UnleashScheduledExecutorImplTest {
+
+    private UnleashScheduledExecutorImpl unleashScheduledExecutor = new UnleashScheduledExecutorImpl();
+    private int periodicalTaskCounter;
+
+    @Test
+    public void scheduleOnce_doNotInterfereWithPeriodicalTasks() {
+        unleashScheduledExecutor.setInterval(this::periodicalTask, 0, 1);
+        unleashScheduledExecutor.scheduleOnce(this::sleep5seconds);
+        sleep5seconds();
+        assertThat(periodicalTaskCounter).isGreaterThan(3);
+    }
+
+    private void sleep5seconds() {
+        try {
+            Thread.sleep(5_000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void periodicalTask() {
+        this.periodicalTaskCounter++;
+    }
+
+}


### PR DESCRIPTION
 - subscribe to all or some events by implementing an UnleashSubscriber
 - improved support for supplying a custom UnleashScheduledExecutor through UnleashConfig
 - default UnleashScheduledExecutor is instantiated lazily
 - isolate periodical task from one-off tasks
 - adding assert4j for more fluent assertions
 - bugfix in FeatureToggleRepository.updateToggles() - do not log error
when status=NOT_CHANGED

targets issue #51