### PR TITLE
fix: Thread safety regarding metrics

### DIFF
--- a/src/main/java/no/finn/unleash/metric/MetricsBucket.java
+++ b/src/main/java/no/finn/unleash/metric/MetricsBucket.java
@@ -4,11 +4,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 class MetricsBucket {
-    private final Map<String, ToggleCount> toggles;
+    private final ConcurrentMap<String, ToggleCount> toggles;
     private final LocalDateTime start;
-    private LocalDateTime stop;
+    private volatile LocalDateTime stop;
 
     MetricsBucket() {
         this.start = LocalDateTime.now(ZoneId.of("UTC"));
@@ -24,11 +25,7 @@ class MetricsBucket {
     }
 
     private ToggleCount getOrCreate(String toggleName) {
-        if(!toggles.containsKey(toggleName)) {
-            ToggleCount counter = new ToggleCount();
-            toggles.put(toggleName, counter);
-        }
-        return toggles.get(toggleName);
+        return toggles.computeIfAbsent(toggleName, s -> new ToggleCount());
     }
 
     void end() {

--- a/src/main/java/no/finn/unleash/metric/ToggleCount.java
+++ b/src/main/java/no/finn/unleash/metric/ToggleCount.java
@@ -1,41 +1,43 @@
 package no.finn.unleash.metric;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 class ToggleCount {
-    private long yes;
-    private long no;
-    private Map<String, Long> variants;
+    private final AtomicLong yes;
+    private final AtomicLong no;
+    private final ConcurrentMap<String, AtomicLong> variants;
 
     public ToggleCount() {
-        this.yes = 0;
-        this.no = 0;
-        this.variants = new HashMap<>();
+        this.yes = new AtomicLong(0);
+        this.no = new AtomicLong(0);
+        this.variants = new ConcurrentHashMap<>();
     }
 
     public void register(boolean active) {
-        if(active) {
-            yes++;
+        if (active) {
+            yes.incrementAndGet();
         } else {
-            no++;
+            no.incrementAndGet();
         }
     }
 
     public void register(String variantName) {
-        Long current = variants.getOrDefault(variantName, 0L);
-        variants.put(variantName, ++current);
+        AtomicLong current = variants.computeIfAbsent(variantName, s -> new AtomicLong());
+        current.incrementAndGet();
     }
 
     public long getYes() {
-        return yes;
+        return yes.get();
     }
 
     public long getNo() {
-        return no;
+        return no.get();
     }
 
-    public Map<String, Long> getVariants() {
+    public Map<String, ? extends Number> getVariants() {
         return variants;
     }
 }

--- a/src/main/java/no/finn/unleash/metric/UnleashMetricServiceImpl.java
+++ b/src/main/java/no/finn/unleash/metric/UnleashMetricServiceImpl.java
@@ -14,7 +14,7 @@ public class UnleashMetricServiceImpl implements UnleashMetricService {
     private final UnleashMetricsSender unleashMetricsSender;
 
     //mutable
-    private MetricsBucket currentMetricsBucket;
+    private volatile MetricsBucket currentMetricsBucket;
 
     public UnleashMetricServiceImpl(UnleashConfig unleashConfig, UnleashScheduledExecutor executor) {
         this(unleashConfig, new UnleashMetricsSender(unleashConfig), executor);

--- a/src/test/java/no/finn/unleash/metric/UnleashMetricServiceImplTest.java
+++ b/src/test/java/no/finn/unleash/metric/UnleashMetricServiceImplTest.java
@@ -164,9 +164,9 @@ public class UnleashMetricServiceImplTest {
         assertNotNull(bucket.getStart());
         assertNotNull(bucket.getStop());
         assertThat(bucket.getToggles().size(), is(1));
-        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v1"), is(3l));
-        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v2"), is(1l));
-        assertThat(bucket.getToggles().get("someToggle").getVariants().get("disabled"), is(1l));
+        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v1").longValue(), is(3l));
+        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v2").longValue(), is(1l));
+        assertThat(bucket.getToggles().get("someToggle").getVariants().get("disabled").longValue(), is(1l));
         assertThat(bucket.getToggles().get("someToggle").getYes(), is(0l));
         assertThat(bucket.getToggles().get("someToggle").getNo(), is(0l));
     }


### PR DESCRIPTION
Fixed a couple of issues regarding metrics when
`MetricsBucket.registerCount` is called concurrently