### PR TITLE
Remove log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <version>3.2.7-SNAPSHOT</version>
 
     <properties>
-        <version.log4j2>2.1</version.log4j2>
+        <version.log4j2>2.11.2</version.log4j2>
         <coberturaFormat>xml</coberturaFormat>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.unleash.specification>3.2.0</version.unleash.specification>


### PR DESCRIPTION
This change upgrades the log4j dependency to a version that is not known to have vulnerabilities. A vulnerability (https://www.cvedetails.com/cve/CVE-2017-5645/) has been reported for the previous version.

Fixes #75