### PR TITLE
feat: Add support for IPv6 and CIDR notation in RemoteAddressStrategy

### DIFF
--- a/src/main/java/no/finn/unleash/strategy/RemoteAddressStrategy.java
+++ b/src/main/java/no/finn/unleash/strategy/RemoteAddressStrategy.java
@@ -1,16 +1,18 @@
 package no.finn.unleash.strategy;
 
+import no.finn.unleash.UnleashContext;
+import no.finn.unleash.util.IpAddressMatcher;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
-
-import no.finn.unleash.UnleashContext;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 public final class RemoteAddressStrategy implements Strategy {
-
-    protected static final String PARAM = "IPs";
+    static final String PARAM = "IPs";
     private static final String STRATEGY_NAME = "remoteAddress";
-
+    private static final Pattern SPLITTER = Pattern.compile(",");
 
     @Override
     public String getName() {
@@ -25,9 +27,23 @@ public final class RemoteAddressStrategy implements Strategy {
     @Override
     public boolean isEnabled(Map<String, String> parameters, UnleashContext context) {
         return Optional.ofNullable(parameters.get(PARAM))
-                .map(ips -> Arrays.asList(ips.split(",\\s*")))
-                .map(ips -> ips.contains(context.getRemoteAddress().orElse(null)))
+                .map(ips -> Arrays.asList(SPLITTER.split(ips, -1)))
+                .map(ips -> ips.stream()
+                        .flatMap(ipAddress -> buildIpAddressMatcher(ipAddress)
+                                .map(Stream::of)
+                                .orElseGet(Stream::empty))
+                        .map(subnet -> context.getRemoteAddress()
+                                .map(subnet::matches)
+                                .orElse(false))
+                        .anyMatch(Boolean.TRUE::equals))
                 .orElse(false);
     }
 
+    private Optional<IpAddressMatcher> buildIpAddressMatcher(String ipAddress) {
+        try {
+            return Optional.of(new IpAddressMatcher(ipAddress));
+        } catch (IllegalArgumentException ex) {
+            return Optional.empty();
+        }
+    }
 }

--- a/src/main/java/no/finn/unleash/util/IpAddressMatcher.java
+++ b/src/main/java/no/finn/unleash/util/IpAddressMatcher.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.finn.unleash.util;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.regex.Pattern;
+
+/**
+ * Matches a request based on IP Address or subnet mask matching against the remote
+ * address.
+ * <p>
+ * Both IPv6 and IPv4 addresses are supported, but a matcher which is configured with an
+ * IPv4 address will never match a request which returns an IPv6 address, and vice-versa.
+ *
+ * @author Luke Taylor
+ */
+public final class IpAddressMatcher {
+    private static final Pattern SPLITTER = Pattern.compile("/");
+    private final int nMaskBits;
+    private final InetAddress requiredAddress;
+
+    /**
+     * Takes a specific IP address or a range specified using the IP/Netmask (e.g.
+     * 192.168.1.0/24 or 202.24.0.0/14).
+     *
+     * @param ipAddress the address or range of addresses from which the request must
+     *                  come.
+     */
+    public IpAddressMatcher(String ipAddress) {
+        final String trimmedIpAddress = ipAddress == null ? "" : ipAddress.trim();
+
+        if (trimmedIpAddress.indexOf('/') > 0) {
+            String[] addressAndMask = SPLITTER.split(trimmedIpAddress, -1);
+            requiredAddress = parseAddress(addressAndMask[0]);
+            nMaskBits = Integer.parseInt(addressAndMask[1]);
+        } else {
+            requiredAddress = parseAddress(trimmedIpAddress);
+            nMaskBits = -1;
+        }
+    }
+
+    public boolean matches(String address) {
+        if (address == null || address.isEmpty() || requiredAddress == null) {
+            return false;
+        }
+
+        InetAddress remoteAddress = parseAddress(address);
+
+        if (!requiredAddress.getClass().equals(remoteAddress.getClass())) {
+            return false;
+        }
+
+        if (nMaskBits < 0) {
+            return remoteAddress.equals(requiredAddress);
+        }
+
+        byte[] remAddr = remoteAddress.getAddress();
+        byte[] reqAddr = requiredAddress.getAddress();
+
+        int oddBits = nMaskBits % 8;
+        int nMaskBytes = nMaskBits / 8 + (oddBits == 0 ? 0 : 1);
+        byte[] mask = new byte[nMaskBytes];
+
+        Arrays.fill(mask, 0, oddBits == 0 ? mask.length : mask.length - 1, (byte) 0xFF);
+
+        if (oddBits != 0) {
+            int finalByte = (1 << oddBits) - 1;
+            finalByte <<= 8 - oddBits;
+            mask[mask.length - 1] = (byte) finalByte;
+        }
+
+        for (int i = 0; i < mask.length; i++) {
+            if ((remAddr[i] & mask[i]) != (reqAddr[i] & mask[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private InetAddress parseAddress(String address) {
+        if (address == null || address.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return InetAddress.getByName(address);
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException("Failed to parse address " + address, e);
+        }
+    }
+}

--- a/src/test/java/no/finn/unleash/strategy/RemoteAddressStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/RemoteAddressStrategyTest.java
@@ -1,11 +1,6 @@
 package no.finn.unleash.strategy;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Stream;
-
+import com.google.common.collect.ImmutableList;
 import no.finn.unleash.UnleashContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,44 +8,87 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class RemoteAddressStrategyTest {
-    private static final String FIRST_IP = "127.0.0.1";
-    private static final String SECOND_IP = "10.0.0.1";
-    private static final String THIRD_IP = "196.0.0.1";
-    private static final List<String> ALL = Arrays.asList(FIRST_IP, SECOND_IP, THIRD_IP);
+class RemoteAddressStrategyTest {
+    private static final String FIRST_IPV4 = "127.0.0.1";
+    private static final String SECOND_IPV4 = "10.0.0.1";
+    private static final String THIRD_IPV4 = "196.0.0.1";
+    private static final String FOURTH_IPV4 = "192.168.42.23";
+    private static final String IPV4_SUBNET = "192.168.0.0/16";
+    private static final List<String> ALL_IPV4 = Arrays.asList(FIRST_IPV4, SECOND_IPV4, THIRD_IPV4, IPV4_SUBNET);
+
+    private static final String FIRST_IPV6 = "::1";
+    private static final String SECOND_IPV6 = "2001:DB8:0:0:0:0:0:1";
+    private static final String THIRD_IPV6 = "2001:DB8::1";
+    private static final String IPV6_SUBNET = "2001:DB8::/48";
+    private static final List<String> ALL_IPV6 = Arrays.asList(FIRST_IPV6, SECOND_IPV6, THIRD_IPV6, IPV6_SUBNET);
+
+    private static final List<String> ALL = ImmutableList.<String>builder()
+            .addAll(ALL_IPV4)
+            .addAll(ALL_IPV6)
+            .build();
 
     private RemoteAddressStrategy strategy;
 
-    public static Stream<Arguments> data() {
+    static Stream<Arguments> data() {
         return Stream.of(
-                Arguments.of(FIRST_IP, FIRST_IP, true),
-                Arguments.of(FIRST_IP, String.join(",", ALL), true),
-                Arguments.of(SECOND_IP, String.join(",", ALL), true),
-                Arguments.of(THIRD_IP, String.join(",", ALL), true),
-                Arguments.of(FIRST_IP, String.join(", ", ALL), true),
-                Arguments.of(SECOND_IP, String.join(", ", ALL), true),
-                Arguments.of(THIRD_IP, String.join(", ", ALL), true),
-                Arguments.of(SECOND_IP, String.join(",  ", ALL), true),
-                Arguments.of(SECOND_IP, String.join(".", ALL), false),
-                Arguments.of(FIRST_IP, SECOND_IP, false));
+                Arguments.of(FIRST_IPV4, FIRST_IPV4, true),
+                Arguments.of(FIRST_IPV4, String.join(",", ALL_IPV4), true),
+                Arguments.of(SECOND_IPV4, String.join(",", ALL_IPV4), true),
+                Arguments.of(THIRD_IPV4, String.join(",", ALL_IPV4), true),
+                Arguments.of(FIRST_IPV4, String.join(", ", ALL_IPV4), true),
+                Arguments.of(SECOND_IPV4, String.join(", ", ALL_IPV4), true),
+                Arguments.of(THIRD_IPV4, String.join(", ", ALL_IPV4), true),
+                Arguments.of(SECOND_IPV4, String.join(",  ", ALL_IPV4), true),
+                Arguments.of(SECOND_IPV4, String.join(".", ALL_IPV4), false),
+                Arguments.of(FIRST_IPV4, SECOND_IPV4, false),
+                Arguments.of(FOURTH_IPV4, String.join(",", ALL_IPV4), true),
+                Arguments.of(FIRST_IPV4, IPV4_SUBNET, false),
+                Arguments.of(FIRST_IPV4, null, false),
+                Arguments.of(FIRST_IPV4, "", false),
+                Arguments.of(null, String.join(",", ALL_IPV4), false),
+
+                Arguments.of(FIRST_IPV6, FIRST_IPV6, true),
+                Arguments.of(FIRST_IPV6, String.join(",", ALL_IPV6), true),
+                Arguments.of(SECOND_IPV6, String.join(",", ALL_IPV6), true),
+                Arguments.of(THIRD_IPV6, String.join(",", ALL_IPV6), true),
+                Arguments.of(FIRST_IPV6, String.join(", ", ALL_IPV6), true),
+                Arguments.of(SECOND_IPV6, String.join(", ", ALL_IPV6), true),
+                Arguments.of(THIRD_IPV6, String.join(", ", ALL_IPV6), true),
+                Arguments.of(SECOND_IPV6, String.join(",  ", ALL_IPV6), true),
+                Arguments.of(SECOND_IPV6, String.join(".", ALL_IPV6), false),
+                Arguments.of(FIRST_IPV6, SECOND_IPV6, false),
+                Arguments.of(FIRST_IPV6, IPV6_SUBNET, false),
+                Arguments.of(FIRST_IPV6, null, false),
+                Arguments.of(FIRST_IPV6, "", false),
+                Arguments.of(null, String.join(".", ALL_IPV6), false),
+
+                Arguments.of(FIRST_IPV4, String.join(".", ALL), false),
+                Arguments.of(FIRST_IPV6, String.join(".", ALL), false));
     }
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         strategy = new RemoteAddressStrategy();
     }
 
     @Test
-    public void should_have_a_name() {
+    void should_have_a_name() {
         assertThat(strategy.getName(), is("remoteAddress"));
     }
 
     @ParameterizedTest
     @MethodSource("data")
-    public void test_all_combinations(String actualIp, String parameterString, boolean expected) {
+    void test_all_combinations(String actualIp, String parameterString, boolean expected) {
         UnleashContext context = UnleashContext.builder().remoteAddress(actualIp).build();
         Map<String, String> parameters = setupParameterMap(parameterString);
 
@@ -58,6 +96,10 @@ public class RemoteAddressStrategyTest {
     }
 
     private Map<String, String> setupParameterMap(String ipString) {
+        if (ipString == null) {
+            return Collections.emptyMap();
+        }
+        
         Map<String, String> parameters = new HashMap<>();
         parameters.put(RemoteAddressStrategy.PARAM, ipString);
         return parameters;

--- a/src/test/java/no/finn/unleash/util/IpAddressMatcherTest.java
+++ b/src/test/java/no/finn/unleash/util/IpAddressMatcherTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2002-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package no.finn.unleash.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Luke Taylor
+ */
+class IpAddressMatcherTest {
+    private final IpAddressMatcher v6matcher = new IpAddressMatcher("fe80::21f:5bff:fe33:bd68");
+    private final IpAddressMatcher v4matcher = new IpAddressMatcher("192.168.1.104");
+
+    @Test
+    void ipv6MatcherMatchesIpv6Address() {
+        assertThat(v6matcher.matches("fe80::21f:5bff:fe33:bd68")).isTrue();
+    }
+
+    @Test
+    void ipv6MatcherDoesntMatchNull() {
+        assertThat(v6matcher.matches(null)).isFalse();
+        assertThat(new IpAddressMatcher("::1").matches(null)).isFalse();
+    }
+
+    @Test
+    void ipv4MatcherDoesntMatchNull() {
+        assertThat(v4matcher.matches(null)).isFalse();
+        assertThat(new IpAddressMatcher("127.0.0.1").matches(null)).isFalse();
+    }
+
+    @Test
+    void ipv6MatcherDoesntMatchIpv4Address() {
+        assertThat(v6matcher.matches("192.168.1.104")).isFalse();
+    }
+
+    @Test
+    void ipv4MatcherMatchesIpv4Address() {
+        assertThat(v4matcher.matches("192.168.1.104")).isTrue();
+    }
+
+    @Test
+    void ipv4SubnetMatchesCorrectly() {
+        IpAddressMatcher matcher = new IpAddressMatcher("192.168.1.0/24");
+        assertThat(matcher.matches("192.168.1.104")).isTrue();
+        matcher = new IpAddressMatcher("192.168.1.128/25");
+        assertThat(matcher.matches("192.168.1.104")).isFalse();
+        assertThat(matcher.matches("192.168.1.159")).isTrue();
+    }
+
+    @Test
+    void ipv6RangeMatches() {
+        IpAddressMatcher matcher = new IpAddressMatcher("2001:DB8::/48");
+
+        assertThat(matcher.matches("2001:DB8:0:0:0:0:0:0")).isTrue();
+        assertThat(matcher.matches("2001:DB8:0:0:0:0:0:1")).isTrue();
+        assertThat(matcher.matches("2001:DB8:0:FFFF:FFFF:FFFF:FFFF:FFFF")).isTrue();
+        assertThat(matcher.matches("2001:DB8:0:ffff:ffff:ffff:ffff:ffff")).isTrue();
+        assertThat(matcher.matches("2001:DB8:1:0:0:0:0:0")).isFalse();
+    }
+
+    @Test
+    void zeroMaskMatchesAnything() {
+        IpAddressMatcher matcher = new IpAddressMatcher("0.0.0.0/0");
+
+        assertThat(matcher.matches("123.4.5.6")).isTrue();
+        assertThat(matcher.matches("192.168.0.159")).isTrue();
+
+        matcher = new IpAddressMatcher("192.168.0.159/0");
+        assertThat(matcher.matches("123.4.5.6")).isTrue();
+        assertThat(matcher.matches("192.168.0.159")).isTrue();
+    }
+}


### PR DESCRIPTION
The `IpAddressMatcher` class has been taken from Spring Security 5.1.5.RELEASE (also Apache 2 licensed).

Source: https://github.com/spring-projects/spring-security/blob/5.1.5.RELEASE/web/src/main/java/org/springframework/security/web/util/matcher/IpAddressMatcher.java

Refs Unleash/unleash-client-node#58
Closes #47