### PR TITLE
Add support for static context fields

### DIFF
--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -45,6 +45,7 @@ public final class DefaultUnleash implements Unleash {
     private final Map<String, Strategy> strategyMap;
     private final UnleashContextProvider contextProvider;
     private final EventDispatcher eventDispatcher;
+    private final UnleashConfig config;
 
 
     private static FeatureToggleRepository defaultToggleRepository(UnleashConfig unleashConfig) {
@@ -60,6 +61,7 @@ public final class DefaultUnleash implements Unleash {
     }
 
     public DefaultUnleash(UnleashConfig unleashConfig, ToggleRepository toggleRepository, Strategy... strategies) {
+        this.config = unleashConfig;
         this.toggleRepository = toggleRepository;
         this.strategyMap = buildStrategyMap(strategies);
         this.contextProvider = unleashConfig.getContextProvider();
@@ -96,8 +98,9 @@ public final class DefaultUnleash implements Unleash {
         } else if(featureToggle.getStrategies().size() == 0) {
             return true;
         } else {
+            UnleashContext enhancedContext = context.applyStaticFields(config);
             enabled = featureToggle.getStrategies().stream()
-                    .anyMatch(as -> getStrategy(as.getName()).isEnabled(as.getParameters(), context));
+                    .anyMatch(as -> getStrategy(as.getName()).isEnabled(as.getParameters(), enhancedContext));
         }
         return enabled;
     }

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -21,6 +21,7 @@ public class UnleashConfig {
     private final UnleashURLs unleashURLs;
     private final Map<String, String> customHttpHeaders;
     private final String appName;
+    private final String environment;
     private final String instanceId;
     private final String sdkVersion;
     private final String backupFile;
@@ -36,6 +37,7 @@ public class UnleashConfig {
             URI unleashAPI,
             Map<String, String> customHttpHeaders,
             String appName,
+            String environment,
             String instanceId,
             String sdkVersion,
             String backupFile,
@@ -73,6 +75,7 @@ public class UnleashConfig {
         this.customHttpHeaders = customHttpHeaders;
         this.unleashURLs = new UnleashURLs(unleashAPI);
         this.appName = appName;
+        this.environment = environment;
         this.instanceId = instanceId;
         this.sdkVersion = sdkVersion;
         this.backupFile = backupFile;
@@ -95,6 +98,10 @@ public class UnleashConfig {
 
     public String getAppName() {
         return appName;
+    }
+
+    public String getEnvironment() {
+        return environment;
     }
 
     public String getInstanceId() {
@@ -156,6 +163,7 @@ public class UnleashConfig {
         private URI unleashAPI;
         private Map<String, String> customHttpHeaders = new HashMap<>();
         private String appName;
+        private String environment = "default";
         private String instanceId = getDefaultInstanceId();
         private String sdkVersion = getDefaultSdkVersion();
         private String backupFile;
@@ -194,6 +202,11 @@ public class UnleashConfig {
 
         public Builder appName(String appName) {
             this.appName = appName;
+            return this;
+        }
+
+        public Builder environment(String environment) {
+            this.environment = environment;
             return this;
         }
 
@@ -256,6 +269,7 @@ public class UnleashConfig {
                     unleashAPI,
                     customHttpHeaders,
                     appName,
+                    environment,
                     instanceId,
                     sdkVersion,
                     getBackupFile(),

--- a/src/test/java/no/finn/unleash/UnleashContextTest.java
+++ b/src/test/java/no/finn/unleash/UnleashContextTest.java
@@ -1,0 +1,100 @@
+package no.finn.unleash;
+
+
+import no.finn.unleash.util.UnleashConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class UnleashContextTest {
+
+    @Test
+    public void should_generate_default_context() {
+        UnleashContext context = UnleashContext.builder().build();
+        assertThat(context.getUserId().isPresent(), is(false));
+        assertThat(context.getSessionId().isPresent(), is(false));
+        assertThat(context.getRemoteAddress().isPresent(), is(false));
+        assertThat(context.getProperties().size(), is(0));
+    }
+
+    @Test
+    public void should_get_context_with_userId() {
+        UnleashContext context = UnleashContext.builder()
+                .userId("test@mail.com")
+                .build();
+        assertThat(context.getUserId().get(), is("test@mail.com"));
+    }
+
+    @Test
+    public void should_get_context_with_fields_set() {
+        UnleashContext context = UnleashContext.builder()
+                .userId("test@mail.com")
+                .sessionId("123")
+                .remoteAddress("127.0.0.1")
+                .environment("prod")
+                .appName("myapp")
+                .addProperty("test", "me")
+                .build();
+
+        assertThat(context.getUserId().get(), is("test@mail.com"));
+        assertThat(context.getSessionId().get(), is("123"));
+        assertThat(context.getRemoteAddress().get(), is("127.0.0.1"));
+        assertThat(context.getEnvironment().get(), is("prod"));
+        assertThat(context.getAppName().get(), is("myapp"));
+        assertThat(context.getProperties().get("test"), is("me"));
+    }
+
+    @Test
+    public void should_apply_context_fields() {
+        UnleashContext context = UnleashContext.builder()
+                .userId("test@mail.com")
+                .sessionId("123")
+                .remoteAddress("127.0.0.1")
+                .addProperty("test", "me")
+                .build();
+
+        UnleashConfig config = UnleashConfig.builder()
+                .unleashAPI("http://test.com")
+                .appName("someApp")
+                .environment("stage")
+                .build();
+
+        UnleashContext enhanced = context.applyStaticFields(config);
+
+        assertThat(enhanced.getUserId().get(), is("test@mail.com"));
+        assertThat(enhanced.getSessionId().get(), is("123"));
+        assertThat(enhanced.getRemoteAddress().get(), is("127.0.0.1"));
+
+        assertThat(enhanced.getEnvironment().get(), is("stage"));
+        assertThat(enhanced.getAppName().get(), is("someApp"));
+    }
+
+    @Test
+    public void should_not_ovveride_static_context_fields() {
+        UnleashContext context = UnleashContext.builder()
+                .userId("test@mail.com")
+                .sessionId("123")
+                .remoteAddress("127.0.0.1")
+                .environment("env")
+                .appName("myApp")
+                .addProperty("test", "me")
+                .build();
+
+        UnleashConfig config = UnleashConfig.builder()
+                .unleashAPI("http://test.com")
+                .appName("someApp")
+                .environment("stage")
+                .build();
+
+
+        UnleashContext enhanced = context.applyStaticFields(config);
+
+        assertThat(enhanced.getUserId().get(), is("test@mail.com"));
+        assertThat(enhanced.getSessionId().get(), is("123"));
+        assertThat(enhanced.getRemoteAddress().get(), is("127.0.0.1"));
+        assertThat(enhanced.getEnvironment().get(), is("env"));
+        assertThat(enhanced.getAppName().get(), is("myApp"));
+    }
+
+}

--- a/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
@@ -81,6 +81,28 @@ public class UnleashConfigTest {
     }
 
     @Test
+    public void should_set_environment_to_default() {
+        UnleashConfig config = UnleashConfig.builder()
+                .appName("my-app")
+                .unleashAPI("http://unleash.org")
+                .build();
+
+        assertThat(config.getEnvironment(), is("default"));
+    }
+
+    @Test
+    public void should_set_environment() {
+        String env = "prod";
+        UnleashConfig config = UnleashConfig.builder()
+                .appName("my-app")
+                .environment(env)
+                .unleashAPI("http://unleash.org")
+                .build();
+
+        assertThat(config.getEnvironment(), is(env));
+    }
+
+    @Test
     public void should_add_app_name_and_instance_id_and_user_agent_to_connection() throws IOException {
         String appName = "my-app";
         String instanceId = "my-instance-1";


### PR DESCRIPTION
Added support for two new static context fields:
- environment
- appName

These are set in the configuration when the client is
initialised and should be inserted in to the UnleashContext.

This is needed in order to provide support for [Strategy Constraints](https://github.com/Unleash/unleash/issues/442#issuecomment-507168912)