### PR TITLE
fix: Make `getFeatures` and `getToggle` public in ToggleCollection

### DIFF
--- a/src/main/java/no/finn/unleash/repository/ToggleCollection.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleCollection.java
@@ -25,11 +25,11 @@ public final class ToggleCollection {
         return features;
     }
 
-    Collection<FeatureToggle> getFeatures() {
+    public Collection<FeatureToggle> getFeatures() {
         return Collections.unmodifiableCollection(features);
     }
 
-    FeatureToggle getToggle(final String name) {
+    public FeatureToggle getToggle(final String name) {
         return cache.get(name);
     }
 }


### PR DESCRIPTION
When implementing an `UnleashSubscriber`, I was attempting to implement a hook for `togglesFetched`.
The argument there is a `FeatureToggleResponse`. That object has a public `getToggleCollection` that returns a `ToggleCollection`.

That object however, is currently useless since it does not expose any get methods, and so my subscriber can't really do anything. 

Since the implementation made sure to return an `unmodifiableCollection`, it seems like an oversight that these methods were not public.