### PR TITLE
feat: Add support for fallback-action 

### DIFF
--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -15,16 +15,7 @@ import no.finn.unleash.repository.FeatureToggleRepository;
 import no.finn.unleash.repository.HttpToggleFetcher;
 import no.finn.unleash.repository.ToggleBackupHandlerFile;
 import no.finn.unleash.repository.ToggleRepository;
-import no.finn.unleash.strategy.ApplicationHostnameStrategy;
-import no.finn.unleash.strategy.DefaultStrategy;
-import no.finn.unleash.strategy.FlexibleRolloutStrategy;
-import no.finn.unleash.strategy.GradualRolloutRandomStrategy;
-import no.finn.unleash.strategy.GradualRolloutSessionIdStrategy;
-import no.finn.unleash.strategy.GradualRolloutUserIdStrategy;
-import no.finn.unleash.strategy.RemoteAddressStrategy;
-import no.finn.unleash.strategy.Strategy;
-import no.finn.unleash.strategy.UnknownStrategy;
-import no.finn.unleash.strategy.UserWithIdStrategy;
+import no.finn.unleash.strategy.*;
 import no.finn.unleash.util.UnleashConfig;
 
 import static java.util.Optional.ofNullable;
@@ -50,6 +41,13 @@ public final class DefaultUnleash implements Unleash {
     private final EventDispatcher eventDispatcher;
     private final UnleashConfig config;
 
+    private static FeatureToggleRepository defaultToggleRepository(UnleashConfig unleashConfig) {
+        return new FeatureToggleRepository(
+                unleashConfig,
+                new HttpToggleFetcher(unleashConfig),
+                new ToggleBackupHandlerFile(unleashConfig)
+        );
+    }
 
     public DefaultUnleash(UnleashConfig unleashConfig, Strategy... strategies) {
         this(unleashConfig, defaultToggleRepository(unleashConfig), strategies);
@@ -63,14 +61,6 @@ public final class DefaultUnleash implements Unleash {
         this.eventDispatcher = new EventDispatcher(unleashConfig);
         this.metricService = new UnleashMetricServiceImpl(unleashConfig, unleashConfig.getScheduledExecutor());
         metricService.register(strategyMap.keySet());
-    }
-
-    private static FeatureToggleRepository defaultToggleRepository(UnleashConfig unleashConfig) {
-        return new FeatureToggleRepository(
-                unleashConfig,
-                new HttpToggleFetcher(unleashConfig),
-                new ToggleBackupHandlerFile(unleashConfig)
-        );
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/FakeUnleash.java
+++ b/src/main/java/no/finn/unleash/FakeUnleash.java
@@ -29,23 +29,8 @@ public final class FakeUnleash implements Unleash {
     }
 
     @Override
-    public boolean isEnabled(String toggleName, boolean defaultSetting, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
-        if(enableAll) {
-            return true;
-        } else if(disableAll) {
-
-            return false;
-        } else {
-            if(!features.containsKey(toggleName)) {
-                return fallbackAction.apply(toggleName, UnleashContext.builder().build());
-            }
-            return features.getOrDefault(toggleName, defaultSetting);
-        }
-    }
-
-    @Override
-    public boolean isEnabled(String toggleName, UnleashContext context, boolean defaultSetting, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
-        return isEnabled(toggleName, defaultSetting, fallbackAction);
+    public boolean isEnabled(String toggleName, UnleashContext context, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        return isEnabled(toggleName, fallbackAction);
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/FakeUnleash.java
+++ b/src/main/java/no/finn/unleash/FakeUnleash.java
@@ -35,16 +35,10 @@ public final class FakeUnleash implements Unleash {
 
     @Override
     public boolean isEnabled(String toggleName, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
-        if(enableAll) {
-            return true;
-        } else if(disableAll) {
-            return false;
-        } else {
-            if(!features.containsKey(toggleName)) {
-                return fallbackAction.apply(toggleName, UnleashContext.builder().build());
-            }
-            return features.getOrDefault(toggleName, false);
+        if(!features.containsKey(toggleName)) {
+            return fallbackAction.apply(toggleName, UnleashContext.builder().build());
         }
+        return isEnabled(toggleName);
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/FakeUnleash.java
+++ b/src/main/java/no/finn/unleash/FakeUnleash.java
@@ -28,6 +28,35 @@ public final class FakeUnleash implements Unleash {
     }
 
     @Override
+    public boolean isEnabled(String toggleName, boolean defaultSetting, FallbackAction fallbackAction) {
+        if(enableAll) {
+            return true;
+        } else if(disableAll) {
+
+            return false;
+        } else {
+            if(!features.containsKey(toggleName)) {
+                fallbackAction.apply(toggleName, UnleashContext.builder().build());
+            }
+            return features.getOrDefault(toggleName, defaultSetting);
+        }
+    }
+
+    @Override
+    public boolean isEnabled(String toggleName, FallbackAction fallbackAction) {
+        if(enableAll) {
+            return true;
+        } else if(disableAll) {
+            return false;
+        } else {
+            if(!features.containsKey(toggleName)) {
+                fallbackAction.apply(toggleName, UnleashContext.builder().build());
+            }
+            return features.getOrDefault(toggleName, false);
+        }
+    }
+
+    @Override
     public Variant getVariant(String toggleName, UnleashContext context) {
         return getVariant(toggleName, Variant.DISABLED_VARIANT);
     }

--- a/src/main/java/no/finn/unleash/FakeUnleash.java
+++ b/src/main/java/no/finn/unleash/FakeUnleash.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 public final class FakeUnleash implements Unleash {
     private boolean enableAll = false;
@@ -28,7 +29,7 @@ public final class FakeUnleash implements Unleash {
     }
 
     @Override
-    public boolean isEnabled(String toggleName, boolean defaultSetting, FallbackAction fallbackAction) {
+    public boolean isEnabled(String toggleName, boolean defaultSetting, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
         if(enableAll) {
             return true;
         } else if(disableAll) {
@@ -36,21 +37,26 @@ public final class FakeUnleash implements Unleash {
             return false;
         } else {
             if(!features.containsKey(toggleName)) {
-                fallbackAction.apply(toggleName, UnleashContext.builder().build());
+                return fallbackAction.apply(toggleName, UnleashContext.builder().build());
             }
             return features.getOrDefault(toggleName, defaultSetting);
         }
     }
 
     @Override
-    public boolean isEnabled(String toggleName, FallbackAction fallbackAction) {
+    public boolean isEnabled(String toggleName, UnleashContext context, boolean defaultSetting, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        return isEnabled(toggleName, defaultSetting, fallbackAction);
+    }
+
+    @Override
+    public boolean isEnabled(String toggleName, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
         if(enableAll) {
             return true;
         } else if(disableAll) {
             return false;
         } else {
             if(!features.containsKey(toggleName)) {
-                fallbackAction.apply(toggleName, UnleashContext.builder().build());
+                return fallbackAction.apply(toggleName, UnleashContext.builder().build());
             }
             return features.getOrDefault(toggleName, false);
         }

--- a/src/main/java/no/finn/unleash/FallbackAction.java
+++ b/src/main/java/no/finn/unleash/FallbackAction.java
@@ -1,5 +1,0 @@
-package no.finn.unleash;
-
-public interface FallbackAction {
-    void apply(String toggleName, UnleashContext unleashContext);
-}

--- a/src/main/java/no/finn/unleash/FallbackAction.java
+++ b/src/main/java/no/finn/unleash/FallbackAction.java
@@ -1,0 +1,5 @@
+package no.finn.unleash;
+
+public interface FallbackAction {
+    void apply(String toggleName, UnleashContext unleashContext);
+}

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -16,7 +16,9 @@ public interface Unleash {
         return isEnabled(toggleName, defaultSetting);
     }
 
-    boolean isEnabled(final String toggleName, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
+    default boolean isEnabled(final String toggleName, final BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        return isEnabled(toggleName, false, fallbackAction);
+    }
 
     boolean isEnabled(final String toggleName, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
 

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -1,6 +1,7 @@
 package no.finn.unleash;
 
 import java.util.List;
+import java.util.function.BiFunction;
 
 public interface Unleash {
     boolean isEnabled(String toggleName);
@@ -15,9 +16,11 @@ public interface Unleash {
         return isEnabled(toggleName, defaultSetting);
     }
 
-    boolean isEnabled(final String toggleName, boolean defaultSetting, final FallbackAction fallbackAction);
+    boolean isEnabled(final String toggleName, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
 
-    boolean isEnabled(final String toggleName, final FallbackAction fallbackAction);
+    boolean isEnabled(final String toggleName, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
+
+    boolean isEnabled(final String toggleName, UnleashContext context, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
 
     Variant getVariant(final String toggleName, final UnleashContext context);
 

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -17,15 +17,11 @@ public interface Unleash {
     }
 
     default boolean isEnabled(final String toggleName, final BiFunction<String, UnleashContext, Boolean> fallbackAction) {
-        return isEnabled(toggleName, false, fallbackAction);
+        return isEnabled(toggleName, false);
     }
 
-    default boolean isEnabled(String toggleName, UnleashContext context, boolean defaultSetting, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
-        return isEnabled(toggleName, defaultSetting, fallbackAction);
-    }
-
-    default boolean isEnabled(final String toggleName, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction) {
-        return isEnabled(toggleName, fallbackAction);
+    default boolean isEnabled(String toggleName, UnleashContext context, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        return isEnabled(toggleName, context, false);
     }
 
     Variant getVariant(final String toggleName, final UnleashContext context);

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -20,9 +20,13 @@ public interface Unleash {
         return isEnabled(toggleName, false, fallbackAction);
     }
 
-    boolean isEnabled(final String toggleName, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
+    default boolean isEnabled(String toggleName, UnleashContext context, boolean defaultSetting, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        return isEnabled(toggleName, defaultSetting, fallbackAction);
+    }
 
-    boolean isEnabled(final String toggleName, UnleashContext context, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction);
+    default boolean isEnabled(final String toggleName, boolean defaultSetting, final BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        return isEnabled(toggleName, fallbackAction);
+    }
 
     Variant getVariant(final String toggleName, final UnleashContext context);
 

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -16,7 +16,7 @@ public interface Unleash {
         return isEnabled(toggleName, defaultSetting);
     }
 
-    default boolean isEnabled(final String toggleName, final BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+    default boolean isEnabled(String toggleName, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
         return isEnabled(toggleName, false);
     }
 

--- a/src/main/java/no/finn/unleash/Unleash.java
+++ b/src/main/java/no/finn/unleash/Unleash.java
@@ -15,6 +15,10 @@ public interface Unleash {
         return isEnabled(toggleName, defaultSetting);
     }
 
+    boolean isEnabled(final String toggleName, boolean defaultSetting, final FallbackAction fallbackAction);
+
+    boolean isEnabled(final String toggleName, final FallbackAction fallbackAction);
+
     Variant getVariant(final String toggleName, final UnleashContext context);
 
     Variant getVariant(final String toggleName, final UnleashContext context, final Variant defaultValue);

--- a/src/test/java/no/finn/unleash/UnleashTest.java
+++ b/src/test/java/no/finn/unleash/UnleashTest.java
@@ -82,6 +82,27 @@ public class UnleashTest {
     }
 
     @Test
+    public void fallback_function_should_be_invoked() {
+        when(toggleRepository.getToggle("test")).thenReturn(null);
+
+        assertThat(unleash.isEnabled("test", (name, unleashContext) -> true), is(true));
+    }
+
+    @Test
+    void fallback_function_should_override_default_fallback_value_when_toggle_not_defined() {
+        when(toggleRepository.getToggle("test")).thenReturn(null);
+
+        assertThat(unleash.isEnabled("test", false, (name, unleashContext) -> true), is(true));
+    }
+
+	@Test
+	void fallback_function_should_not_be_called_when_toggle_is_defined() {
+		when(toggleRepository.getToggle("test")).thenReturn(new FeatureToggle("test", true, asList(new ActivationStrategy("default", null))));
+
+		assertThat(unleash.isEnabled("test", false, (name, unleashContext) -> true), is(true));
+	}
+
+    @Test
     public void should_register_custom_strategies() {
         //custom strategy
         Strategy customStrategy = mock(Strategy.class);

--- a/src/test/java/no/finn/unleash/UnleashTest.java
+++ b/src/test/java/no/finn/unleash/UnleashTest.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 import no.finn.unleash.repository.ToggleRepository;
 import no.finn.unleash.strategy.Strategy;
@@ -15,21 +17,18 @@ import no.finn.unleash.util.UnleashConfig;
 
 import no.finn.unleash.variant.Payload;
 import no.finn.unleash.variant.VariantDefinition;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 public class UnleashTest {
 
@@ -82,24 +81,46 @@ public class UnleashTest {
     }
 
     @Test
-    public void fallback_function_should_be_invoked() {
+    public void fallback_function_should_be_invoked_and_return_true() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
+        BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
+        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(true);
 
-        assertThat(unleash.isEnabled("test", (name, unleashContext) -> true), is(true));
+        assertThat(unleash.isEnabled("test", fallbackAction), is(true));
+        verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
     }
 
     @Test
-    void fallback_function_should_override_default_fallback_value_when_toggle_not_defined() {
+    public void fallback_function_should_be_invoked_also_with_context() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
+        BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
+        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(true);
 
-        assertThat(unleash.isEnabled("test", (name, unleashContext) -> true), is(true));
+        UnleashContext context = UnleashContext.builder().userId("123").build();
+
+        assertThat(unleash.isEnabled("test", context, fallbackAction), is(true));
+        verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
+    }
+
+    @Test
+    void fallback_function_should_be_invoked_and_return_false() {
+        when(toggleRepository.getToggle("test")).thenReturn(null);
+        BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
+        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(false);
+
+        assertThat(unleash.isEnabled("test", fallbackAction), is(false));
+        verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
     }
 
 	@Test
 	void fallback_function_should_not_be_called_when_toggle_is_defined() {
 		when(toggleRepository.getToggle("test")).thenReturn(new FeatureToggle("test", true, asList(new ActivationStrategy("default", null))));
 
-		assertThat(unleash.isEnabled("test", (name, unleashContext) -> false), is(true));
+        BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
+        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(false);
+
+		assertThat(unleash.isEnabled("test", fallbackAction), is(true));
+        verify(fallbackAction, never()).apply(anyString(), any(UnleashContext.class));
 	}
 
     @Test

--- a/src/test/java/no/finn/unleash/UnleashTest.java
+++ b/src/test/java/no/finn/unleash/UnleashTest.java
@@ -99,7 +99,7 @@ public class UnleashTest {
 	void fallback_function_should_not_be_called_when_toggle_is_defined() {
 		when(toggleRepository.getToggle("test")).thenReturn(new FeatureToggle("test", true, asList(new ActivationStrategy("default", null))));
 
-		assertThat(unleash.isEnabled("test", false, (name, unleashContext) -> true), is(true));
+		assertThat(unleash.isEnabled("test", false, (name, unleashContext) -> false), is(true));
 	}
 
     @Test

--- a/src/test/java/no/finn/unleash/UnleashTest.java
+++ b/src/test/java/no/finn/unleash/UnleashTest.java
@@ -92,14 +92,14 @@ public class UnleashTest {
     void fallback_function_should_override_default_fallback_value_when_toggle_not_defined() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
 
-        assertThat(unleash.isEnabled("test", false, (name, unleashContext) -> true), is(true));
+        assertThat(unleash.isEnabled("test", (name, unleashContext) -> true), is(true));
     }
 
 	@Test
 	void fallback_function_should_not_be_called_when_toggle_is_defined() {
 		when(toggleRepository.getToggle("test")).thenReturn(new FeatureToggle("test", true, asList(new ActivationStrategy("default", null))));
 
-		assertThat(unleash.isEnabled("test", false, (name, unleashContext) -> false), is(true));
+		assertThat(unleash.isEnabled("test", (name, unleashContext) -> false), is(true));
 	}
 
     @Test


### PR DESCRIPTION
Today it is possible to define a fallback value which the `isEnabled` will return if the feature toggle is not defined.

We want to also allow the user to send in a fallbackFunction instead of a fallback value (which will take precedence over fallback value).

The fallback function should get to arguments injected: `toggleName` and the enhanced `unleashContext`. The function is implemented by the caller and should return a boolean value. 

Example on how it would work:
`isEnabled("someToggle", context, (toggleName, eContext) -> false)`