### PR TITLE
Fix java.lang.NullPointerException when no variants defined

### DIFF
--- a/src/main/java/no/finn/unleash/FeatureToggle.java
+++ b/src/main/java/no/finn/unleash/FeatureToggle.java
@@ -1,5 +1,6 @@
 package no.finn.unleash;
 
+import java.util.Collections;
 import java.util.List;
 
 import no.finn.unleash.variant.VariantDefinition;
@@ -36,7 +37,11 @@ public final class FeatureToggle {
     }
 
     public List<VariantDefinition> getVariants() {
-        return variants;
+        if(variants == null) {
+            return Collections.emptyList();
+        } else {
+            return variants;
+        }
     }
 
     @Override


### PR DESCRIPTION
java.lang.NullPointerException: null	
at no.finn.unleash.variant.VariantUtil.selectVariant(VariantUtil.java:52) ~[unleash-client-java-3.2.10.jar:3.2.10]

When there are feature toggles with no variants defined if you try to do getVariant from DefaultUnleash. this is because when you do deserializeVersion1 variants is null and not un empty collection.