### PR TITLE
fix: add a custom http headers provider for unleash config class

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,29 @@ UnleashConfig unleashConfig = UnleashConfig.builder()
                 .build();
 ```
 
+###Dynamic custom HTTP headers
+If you need custom http headers that change during the lifetime of the client, a provider can be defined via the `UnleashConfig`.
+```java
+public class CustomHttpHeadersProviderImpl implements CustomHttpHeadersProvider {
+    @Override
+    public Map<String, String> getCustomHeaders() {
+        String token = "Acquire or refresh token";
+        return new HashMap() {{ put("Authorization", "Bearer "+token); }};
+    }
+}
+```
+```java
+CustomHttpHeadersProvider provider = new CustomHttpHeadersProviderImpl();
+
+UnleashConfig unleashConfig = UnleashConfig.builder()
+                .appName("my-app")
+                .instanceId("my-instance-1")
+                .unleashAPI(unleashAPI)
+                .customHttpHeadersProvider(provider)
+                .build();
+```
+
+
 ### Subscriber API
 *(Introduced in 3.2.2)*
 

--- a/src/main/java/no/finn/unleash/CustomHttpHeadersProvider.java
+++ b/src/main/java/no/finn/unleash/CustomHttpHeadersProvider.java
@@ -1,0 +1,7 @@
+package no.finn.unleash;
+
+import java.util.Map;
+
+public interface CustomHttpHeadersProvider {
+    Map<String, String> getCustomHeaders();
+}

--- a/src/main/java/no/finn/unleash/DefaultCustomHttpHeadersProviderImpl.java
+++ b/src/main/java/no/finn/unleash/DefaultCustomHttpHeadersProviderImpl.java
@@ -1,0 +1,11 @@
+package no.finn.unleash;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DefaultCustomHttpHeadersProviderImpl implements CustomHttpHeadersProvider {
+    @Override
+    public Map<String, String> getCustomHeaders() {
+        return new HashMap<>();
+    }
+}

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -1,5 +1,7 @@
 package no.finn.unleash.util;
 
+import no.finn.unleash.CustomHttpHeadersProvider;
+import no.finn.unleash.DefaultCustomHttpHeadersProviderImpl;
 import no.finn.unleash.UnleashContextProvider;
 import no.finn.unleash.event.NoOpSubscriber;
 import no.finn.unleash.event.UnleashSubscriber;
@@ -18,6 +20,7 @@ public class UnleashConfig {
     private final URI unleashAPI;
     private final UnleashURLs unleashURLs;
     private final Map<String, String> customHttpHeaders;
+    private final CustomHttpHeadersProvider customHttpHeadersProvider;
     private final String appName;
     private final String environment;
     private final String instanceId;
@@ -35,6 +38,7 @@ public class UnleashConfig {
     public UnleashConfig(
             URI unleashAPI,
             Map<String, String> customHttpHeaders,
+            CustomHttpHeadersProvider customHttpHeadersProvider,
             String appName,
             String environment,
             String instanceId,
@@ -76,6 +80,7 @@ public class UnleashConfig {
 
         this.unleashAPI = unleashAPI;
         this.customHttpHeaders = customHttpHeaders;
+        this.customHttpHeadersProvider = customHttpHeadersProvider;
         this.unleashURLs = new UnleashURLs(unleashAPI);
         this.appName = appName;
         this.environment = environment;
@@ -101,6 +106,7 @@ public class UnleashConfig {
         connection.setRequestProperty(UNLEASH_INSTANCE_ID_HEADER, config.getInstanceId());
         connection.setRequestProperty("User-Agent", config.getAppName());
         config.getCustomHttpHeaders().forEach(connection::setRequestProperty);
+        config.customHttpHeadersProvider.getCustomHeaders().forEach(connection::setRequestProperty);
     }
 
     private void enableProxyAuthentication() {
@@ -115,6 +121,8 @@ public class UnleashConfig {
     public Map<String, String> getCustomHttpHeaders() {
         return customHttpHeaders;
     }
+
+    public CustomHttpHeadersProvider getCustomHttpHeadersProvider() { return customHttpHeadersProvider; }
 
     public String getAppName() {
         return appName;
@@ -196,6 +204,7 @@ public class UnleashConfig {
 
         private URI unleashAPI;
         private Map<String, String> customHttpHeaders = new HashMap<>();
+        private CustomHttpHeadersProvider customHttpHeadersProvider = new DefaultCustomHttpHeadersProviderImpl();
         private String appName;
         private String environment = "default";
         private String instanceId = getDefaultInstanceId();
@@ -232,6 +241,11 @@ public class UnleashConfig {
 
         public Builder customHttpHeader(String name, String value) {
             this.customHttpHeaders.put(name, value);
+            return this;
+        }
+
+        public Builder customHttpHeadersProvider(CustomHttpHeadersProvider provider) {
+            this.customHttpHeadersProvider = provider;
             return this;
         }
 
@@ -308,6 +322,7 @@ public class UnleashConfig {
             return new UnleashConfig(
                     unleashAPI,
                     customHttpHeaders,
+                    customHttpHeadersProvider,
                     appName,
                     environment,
                     instanceId,


### PR DESCRIPTION
This will make it possible to acquire a new or refresh auth tokens when talking to the server.  This also addresses the following issue.  https://github.com/Unleash/unleash-client-java/issues/94