### PR TITLE
fix: Make ToggleCollection constructor public

### DIFF
--- a/src/main/java/no/finn/unleash/repository/ToggleCollection.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleCollection.java
@@ -12,7 +12,7 @@ public final class ToggleCollection {
     private final int version = 1; // required for serialization
     private final transient Map<String, FeatureToggle> cache;
 
-    ToggleCollection(final Collection<FeatureToggle> features) {
+    public ToggleCollection(final Collection<FeatureToggle> features) {
         this.features = ensureNotNull(features);
         this.cache = new ConcurrentHashMap<>();
         for(FeatureToggle featureToggle : this.features) {


### PR DESCRIPTION
I am currently implementing my own `ToggleFetcher` that uses a Scala http4s client for fetching the toggles, and the constructor for `ToggleCollection` not being public is stopping me from doing so. All of the other constructors needed to make a `FeatureToggleResponse` are already public so I presume this was an oversight rather than a deliberate design decision.