### PR TITLE
Correct README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Unleash Client SDK for Java
-This is the Unleash Client SDK for Java. It is compatible with the [Unlesah-hosted.com SaaS](https://www.unleash-hosted.com/) offering and [Unleash Open-Source](https://github.com/unleash/unleash).
+This is the Unleash Client SDK for Java. It is compatible with the [Unleash-hosted.com SaaS](https://www.unleash-hosted.com/) offering and [Unleash Open-Source](https://github.com/unleash/unleash).
 
 
 [![Build Status](https://travis-ci.org/Unleash/unleash-client-java.svg?branch=master)](https://travis-ci.org/Unleash/unleash-client-java)


### PR DESCRIPTION
I know this is low-hanging fruit, but I wanted to go ahead and submit a correction to the typo in README.md around the Unleash-hosted.com name.

Feel free to merge or to just make the change directly in your repo and discard this PR.