### PR TITLE
fix: follow redirect once

### DIFF
--- a/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
+++ b/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
@@ -11,8 +11,12 @@ import java.util.Optional;
 
 import no.finn.unleash.UnleashException;
 import no.finn.unleash.util.UnleashConfig;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public final class HttpToggleFetcher implements ToggleFetcher {
+    private static final Logger LOG = LogManager.getLogger(HttpToggleFetcher.class);
+
     private static final int CONNECT_TIMEOUT = 10000;
     private Optional<String> etag = Optional.empty();
 
@@ -70,6 +74,7 @@ public final class HttpToggleFetcher implements ToggleFetcher {
 
         request = openConnection(new URL(newUrl));
         request.connect();
+        LOG.info("Redirecting from {} to {}. Please consider to update your config.", toggleUrl, newUrl);
 
         return getToggleResponse(request, false);
     }

--- a/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
+++ b/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
@@ -233,28 +233,26 @@ public class HttpToggleFetcherTest {
                 .withHeader("Content-Type", matching("application/json")));
     }
 
-    @Test
-    public void should_handle_errors() throws URISyntaxException {
-        int httpCodes[] = {400,401,403,404,500,503};
-        for(int httpCode:httpCodes) {
-            stubFor(get(urlEqualTo("/api/client/features"))
-                    .withHeader("Accept", equalTo("application/json"))
-                    .willReturn(aResponse()
-                            .withStatus(httpCode)
-                            .withHeader("Content-Type", "application/json")));
+    @ParameterizedTest
+    @ValueSource(ints = {400, 401, 403, 404, 500, 503})
+    public void should_handle_errors(int httpCode) throws URISyntaxException {
+        stubFor(get(urlEqualTo("/api/client/features"))
+                .withHeader("Accept", equalTo("application/json"))
+                .willReturn(aResponse()
+                        .withStatus(httpCode)
+                        .withHeader("Content-Type", "application/json")));
 
-            URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
-            UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
-            HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
-            FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
-            assertEquals(response.getStatus(), FeatureToggleResponse.Status.UNAVAILABLE,
-                    "Should return status UNAVAILABLE");
-            assertEquals(response.getHttpStatusCode(), httpCode,
-                    "Should return correct status code");
+        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
+        HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
+        FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
+        assertEquals(response.getStatus(), FeatureToggleResponse.Status.UNAVAILABLE,
+                "Should return status UNAVAILABLE");
+        assertEquals(response.getHttpStatusCode(), httpCode,
+                "Should return correct status code");
 
-            verify(getRequestedFor(urlMatching("/api/client/features"))
-                    .withHeader("Content-Type", matching("application/json")));
-        }
+        verify(getRequestedFor(urlMatching("/api/client/features"))
+                .withHeader("Content-Type", matching("application/json")));
 
     }
 

--- a/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
+++ b/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
@@ -10,7 +10,10 @@ import no.finn.unleash.FeatureToggle;
 import no.finn.unleash.util.UnleashConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -202,17 +205,18 @@ public class HttpToggleFetcherTest {
                 .withHeader("Content-Type", matching("application/json")));
     }
 
-    @Test
-    public void should_handle_redirect() throws URISyntaxException {
+    @ParameterizedTest
+    @ValueSource(ints = {HttpURLConnection.HTTP_MOVED_PERM, HttpURLConnection.HTTP_MOVED_TEMP, HttpURLConnection.HTTP_SEE_OTHER})
+    public void should_handle_redirect(int responseCode) throws URISyntaxException {
         stubFor(get(urlEqualTo("/api/client/features"))
                 .withHeader("Accept", equalTo("application/json"))
                 .willReturn(aResponse()
-                        .withStatus(302)
+                        .withStatus(responseCode)
                         .withHeader("Location", "http://localhost:" + serverMock.port() + "/api/v2/client/features")));
         stubFor(get(urlEqualTo("/api/v2/client/features"))
                 .withHeader("Accept", equalTo("application/json"))
                 .willReturn(aResponse()
-                        .withStatus(200)
+                        .withStatus(HttpURLConnection.HTTP_OK)
                         .withHeader("Content-Type", "application/json")
                         .withBodyFile("features-v1.json")));
 


### PR DESCRIPTION
This PR adds the ability to follow redirects (HTTP 301 - 303). To prevent infinite loops this is done only once. This PR fixes #113   