### PR TITLE
Migrate to Slf4j for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.0
+- feat: Switched to slf4j-api logging
+- feat: add support for filtering on project or tags
 ## 3.3.4
 - fix: follow redirect once (#115)
 - chore(deps): bump version.log4j2 from 2.11.2 to 2.13.3 (#109)

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,9 @@
     <version>3.3.5-SNAPSHOT</version>
 
     <properties>
+        <version.slf4j>1.7.30</version.slf4j>
         <version.log4j2>2.13.3</version.log4j2>
-        <version.junit5>5.4.2</version.junit5>
+        <version.junit5>5.7.0</version.junit5>
         <coberturaFormat>xml</coberturaFormat>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.unleash.specification>3.3.0</version.unleash.specification>
@@ -44,13 +45,13 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.6</version>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${version.log4j2}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${version.slf4j}</version>
         </dependency>
 
         <dependency>
@@ -75,49 +76,35 @@
 
         <!-- Legacy support -->
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${version.junit5}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.12.2</version>
+            <version>3.19.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>3.7.7</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
-            <version>2.23.2</version>
+            <version>2.27.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.github.JensPiegsa</groupId>
             <artifactId>wiremock-extension</artifactId>
-            <version>0.1.2</version>
+            <version>0.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
+            <artifactId>log4j-slf4j-impl</artifactId>
             <version>${version.log4j2}</version>
             <scope>test</scope>
         </dependency>
@@ -146,7 +133,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -172,7 +159,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.4</version>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -202,7 +189,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>wagon-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.2</version>
                 <executions>
                     <execution>
                         <id>download-client-specifications</id>
@@ -244,8 +231,9 @@
 
             <!--Move & rename client-specification-->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>move-client-specification</id>

--- a/src/main/java/no/finn/unleash/event/Log4JSubscriber.java
+++ b/src/main/java/no/finn/unleash/event/Log4JSubscriber.java
@@ -1,25 +1,40 @@
 package no.finn.unleash.event;
 
 import no.finn.unleash.UnleashException;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import static org.slf4j.event.Level.*;
 
 public class Log4JSubscriber implements UnleashSubscriber {
 
-    private static final Logger LOG = LogManager.getLogger(Log4JSubscriber.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Log4JSubscriber.class);
 
-    private Level eventLevel = Level.INFO;
-    private Level errorLevel = Level.WARN;
+    private Level eventLevel = INFO;
+    private Level errorLevel = WARN;
 
     @Override
     public void on(UnleashEvent unleashEvent) {
-        LOG.log(eventLevel, unleashEvent.toString());
+        switch(eventLevel) {
+            case DEBUG: LOG.debug(unleashEvent.toString()); break;
+            case INFO: LOG.info(unleashEvent.toString()); break;
+            case WARN: LOG.warn(unleashEvent.toString()); break;
+            case ERROR: LOG.error(unleashEvent.toString()); break;
+            case TRACE: LOG.trace(unleashEvent.toString()); break;
+        }
     }
+
 
     @Override
     public void onError(UnleashException unleashException) {
-        LOG.log(errorLevel, unleashException.getMessage(), unleashException);
+        switch(errorLevel) {
+            case WARN: LOG.warn(unleashException.getMessage(), unleashException); break;
+            case ERROR: LOG.error(unleashException.getMessage(), unleashException); break;
+            case INFO: LOG.info(unleashException.getMessage(), unleashException); break;
+            case DEBUG: LOG.debug(unleashException.getMessage(), unleashException); break;
+            case TRACE: LOG.trace(unleashException.getMessage(), unleashException); break;
+        }
     }
 
     public Log4JSubscriber setEventLevel(Level eventLevel) {

--- a/src/main/java/no/finn/unleash/event/UnleashSubscriber.java
+++ b/src/main/java/no/finn/unleash/event/UnleashSubscriber.java
@@ -5,12 +5,12 @@ import no.finn.unleash.metric.ClientMetrics;
 import no.finn.unleash.metric.ClientRegistration;
 import no.finn.unleash.repository.FeatureToggleResponse;
 import no.finn.unleash.repository.ToggleCollection;
-import org.apache.logging.log4j.LogManager;
+import org.slf4j.LoggerFactory;
 
 public interface UnleashSubscriber {
 
     default void onError(UnleashException unleashException) {
-        LogManager.getLogger(UnleashSubscriber.class).warn(unleashException.getMessage(), unleashException);
+        LoggerFactory.getLogger(UnleashSubscriber.class).warn(unleashException.getMessage(), unleashException);
     }
 
     default void on(UnleashEvent unleashEvent) { }

--- a/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
+++ b/src/main/java/no/finn/unleash/metric/UnleashMetricsSender.java
@@ -5,8 +5,6 @@ import no.finn.unleash.UnleashException;
 import no.finn.unleash.event.EventDispatcher;
 import no.finn.unleash.util.UnleashConfig;
 import no.finn.unleash.util.UnleashURLs;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;

--- a/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
+++ b/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
@@ -11,11 +11,11 @@ import java.util.Optional;
 
 import no.finn.unleash.UnleashException;
 import no.finn.unleash.util.UnleashConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class HttpToggleFetcher implements ToggleFetcher {
-    private static final Logger LOG = LogManager.getLogger(HttpToggleFetcher.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpToggleFetcher.class);
 
     private static final int CONNECT_TIMEOUT = 10000;
     private Optional<String> etag = Optional.empty();

--- a/src/main/java/no/finn/unleash/repository/ToggleBackupHandlerFile.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleBackupHandlerFile.java
@@ -6,16 +6,16 @@ import no.finn.unleash.event.EventDispatcher;
 import no.finn.unleash.event.UnleashEvent;
 import no.finn.unleash.event.UnleashSubscriber;
 import no.finn.unleash.util.UnleashConfig;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.*;
 import java.util.Collections;
 import java.util.List;
 import com.google.gson.JsonParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ToggleBackupHandlerFile implements ToggleBackupHandler {
-    private static final Logger LOG = LogManager.getLogger(ToggleBackupHandlerFile.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ToggleBackupHandlerFile.class);
 
     private final String backupFile;
     private final EventDispatcher eventDispatcher;

--- a/src/main/java/no/finn/unleash/util/UnleashScheduledExecutorImpl.java
+++ b/src/main/java/no/finn/unleash/util/UnleashScheduledExecutorImpl.java
@@ -1,13 +1,13 @@
 package no.finn.unleash.util;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.*;
 
 public class UnleashScheduledExecutorImpl implements UnleashScheduledExecutor {
 
-    private static final Logger LOG = LogManager.getLogger(UnleashScheduledExecutorImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UnleashScheduledExecutorImpl.class);
 
     private static UnleashScheduledExecutorImpl INSTANCE;
 

--- a/src/test/java/no/finn/unleash/FakeUnleashTest.java
+++ b/src/test/java/no/finn/unleash/FakeUnleashTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FakeUnleashTest {
 
@@ -16,8 +14,8 @@ public class FakeUnleashTest {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.enableAll();
 
-        assertThat(fakeUnleash.isEnabled("unknown"), is(true));
-        assertThat(fakeUnleash.isEnabled("unknown2"), is(true));
+        assertThat(fakeUnleash.isEnabled("unknown")).isTrue();
+        assertThat(fakeUnleash.isEnabled("unknown2")).isTrue();
     }
 
     @Test
@@ -25,9 +23,9 @@ public class FakeUnleashTest {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.enable("t1", "t2");
 
-        assertThat(fakeUnleash.isEnabled("t1"), is(true));
-        assertThat(fakeUnleash.isEnabled("t2"), is(true));
-        assertThat(fakeUnleash.isEnabled("unknown"), is(false));
+        assertThat(fakeUnleash.isEnabled("t1")).isTrue();
+        assertThat(fakeUnleash.isEnabled("t2")).isTrue();
+        assertThat(fakeUnleash.isEnabled("unknown")).isFalse();
     }
 
     @Test
@@ -36,7 +34,7 @@ public class FakeUnleashTest {
         fakeUnleash.enable("t1", "t2");
         fakeUnleash.disableAll();
 
-        assertThat(fakeUnleash.isEnabled("t1"), is(false));
+        assertThat(fakeUnleash.isEnabled("t1")).isFalse();
     }
 
     @Test
@@ -45,8 +43,8 @@ public class FakeUnleashTest {
         fakeUnleash.enable("t1", "t2");
         fakeUnleash.disable("t2");
 
-        assertThat(fakeUnleash.isEnabled("t1"), is(true));
-        assertThat(fakeUnleash.isEnabled("t2"), is(false));
+        assertThat(fakeUnleash.isEnabled("t1")).isTrue();
+        assertThat(fakeUnleash.isEnabled("t2")).isFalse();
     }
 
     @Test
@@ -54,7 +52,7 @@ public class FakeUnleashTest {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.disable("t1");
 
-        assertThat(fakeUnleash.isEnabled("t1", true), is(false));
+        assertThat(fakeUnleash.isEnabled("t1", true)).isFalse();
     }
 
     @Test
@@ -62,7 +60,7 @@ public class FakeUnleashTest {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.disableAll();
 
-        assertThat(fakeUnleash.isEnabled("t1", true), is(false));
+        assertThat(fakeUnleash.isEnabled("t1", true)).isFalse();
     }
 
     @Test
@@ -70,7 +68,7 @@ public class FakeUnleashTest {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.disable("t1");
         fakeUnleash.resetAll();
-        assertThat(fakeUnleash.isEnabled("t1", true), is(true));
+        assertThat(fakeUnleash.isEnabled("t1", true)).isTrue();
 
     }
 
@@ -81,8 +79,8 @@ public class FakeUnleashTest {
         fakeUnleash.disable("t2");
         fakeUnleash.reset("t1");
 
-        assertThat(fakeUnleash.isEnabled("t1", true), is(true));
-        assertThat(fakeUnleash.isEnabled("t2", true), is(false));
+        assertThat(fakeUnleash.isEnabled("t1", true)).isTrue();
+        assertThat(fakeUnleash.isEnabled("t2", true)).isFalse();
 
     }
 
@@ -93,7 +91,7 @@ public class FakeUnleashTest {
         fakeUnleash.disable("t2");
 
         List<String> expected = Arrays.asList(new String[]{"t1", "t2"});
-        assertTrue(fakeUnleash.getFeatureToggleNames().containsAll(expected));
+        assertThat(fakeUnleash.getFeatureToggleNames()).containsAll(expected);
     }
 
     @Test
@@ -102,7 +100,7 @@ public class FakeUnleashTest {
         fakeUnleash.enable("t1", "t2");
         fakeUnleash.setVariant("t1", new Variant("a", (String) null, true));
 
-        assertThat(fakeUnleash.getVariant("t1").getName(), is("a"));
+        assertThat(fakeUnleash.getVariant("t1").getName()).isEqualTo("a");
     }
 
     @Test
@@ -111,7 +109,7 @@ public class FakeUnleashTest {
         fakeUnleash.disable("t1", "t2");
         fakeUnleash.setVariant("t1", new Variant("a", (String) null, true));
 
-        assertThat(fakeUnleash.getVariant("t1").getName(), is("disabled"));
+        assertThat(fakeUnleash.getVariant("t1").getName()).isEqualTo("disabled");
     }
 
 }

--- a/src/test/java/no/finn/unleash/SynchronousTestExecutor.java
+++ b/src/test/java/no/finn/unleash/SynchronousTestExecutor.java
@@ -2,7 +2,8 @@ package no.finn.unleash;
 
 import no.finn.unleash.util.UnleashScheduledExecutor;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Delayed;
 import java.util.concurrent.RejectedExecutionException;
@@ -11,7 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 public class SynchronousTestExecutor implements UnleashScheduledExecutor {
 
-    private static final Logger LOG = LogManager.getLogger(SynchronousTestExecutor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SynchronousTestExecutor.class);
 
     @Override
     public ScheduledFuture setInterval(Runnable command, long initialDelaySec, long periodSec) throws RejectedExecutionException {

--- a/src/test/java/no/finn/unleash/UnleashContextTest.java
+++ b/src/test/java/no/finn/unleash/UnleashContextTest.java
@@ -4,18 +4,18 @@ package no.finn.unleash;
 import no.finn.unleash.util.UnleashConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class UnleashContextTest {
 
     @Test
     public void should_generate_default_context() {
         UnleashContext context = UnleashContext.builder().build();
-        assertThat(context.getUserId().isPresent(), is(false));
-        assertThat(context.getSessionId().isPresent(), is(false));
-        assertThat(context.getRemoteAddress().isPresent(), is(false));
-        assertThat(context.getProperties().size(), is(0));
+        assertThat(context.getUserId()).isEmpty();
+        assertThat(context.getSessionId()).isEmpty();
+        assertThat(context.getRemoteAddress()).isEmpty();
+        assertThat(context.getProperties()).isEmpty();
     }
 
     @Test
@@ -23,7 +23,7 @@ public class UnleashContextTest {
         UnleashContext context = UnleashContext.builder()
                 .userId("test@mail.com")
                 .build();
-        assertThat(context.getUserId().get(), is("test@mail.com"));
+        assertThat(context.getUserId()).hasValue("test@mail.com");
     }
 
     @Test
@@ -37,12 +37,12 @@ public class UnleashContextTest {
                 .addProperty("test", "me")
                 .build();
 
-        assertThat(context.getUserId().get(), is("test@mail.com"));
-        assertThat(context.getSessionId().get(), is("123"));
-        assertThat(context.getRemoteAddress().get(), is("127.0.0.1"));
-        assertThat(context.getEnvironment().get(), is("prod"));
-        assertThat(context.getAppName().get(), is("myapp"));
-        assertThat(context.getProperties().get("test"), is("me"));
+        assertThat(context.getUserId()).hasValue("test@mail.com");
+        assertThat(context.getSessionId()).hasValue("123");
+        assertThat(context.getRemoteAddress()).hasValue("127.0.0.1");
+        assertThat(context.getEnvironment()).hasValue("prod");
+        assertThat(context.getAppName()).hasValue("myapp");
+        assertThat(context.getProperties().get("test")).isEqualTo("me");
     }
 
     @Test
@@ -62,12 +62,12 @@ public class UnleashContextTest {
 
         UnleashContext enhanced = context.applyStaticFields(config);
 
-        assertThat(enhanced.getUserId().get(), is("test@mail.com"));
-        assertThat(enhanced.getSessionId().get(), is("123"));
-        assertThat(enhanced.getRemoteAddress().get(), is("127.0.0.1"));
+        assertThat(enhanced.getUserId()).hasValue("test@mail.com");
+        assertThat(enhanced.getSessionId()).hasValue("123");
+        assertThat(enhanced.getRemoteAddress()).hasValue("127.0.0.1");
 
-        assertThat(enhanced.getEnvironment().get(), is("stage"));
-        assertThat(enhanced.getAppName().get(), is("someApp"));
+        assertThat(enhanced.getEnvironment()).hasValue("stage");
+        assertThat(enhanced.getAppName()).hasValue("someApp");
     }
 
     @Test
@@ -90,11 +90,11 @@ public class UnleashContextTest {
 
         UnleashContext enhanced = context.applyStaticFields(config);
 
-        assertThat(enhanced.getUserId().get(), is("test@mail.com"));
-        assertThat(enhanced.getSessionId().get(), is("123"));
-        assertThat(enhanced.getRemoteAddress().get(), is("127.0.0.1"));
-        assertThat(enhanced.getEnvironment().get(), is("env"));
-        assertThat(enhanced.getAppName().get(), is("myApp"));
+        assertThat(enhanced.getUserId()).hasValue("test@mail.com");
+        assertThat(enhanced.getSessionId()).hasValue("123");
+        assertThat(enhanced.getRemoteAddress()).hasValue("127.0.0.1");
+        assertThat(enhanced.getEnvironment()).hasValue("env");
+        assertThat(enhanced.getAppName()).hasValue("myApp");
     }
 
 }

--- a/src/test/java/no/finn/unleash/UnleashTest.java
+++ b/src/test/java/no/finn/unleash/UnleashTest.java
@@ -1,32 +1,19 @@
 package no.finn.unleash;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-
 import no.finn.unleash.repository.ToggleRepository;
 import no.finn.unleash.strategy.Strategy;
 import no.finn.unleash.strategy.UserWithIdStrategy;
 import no.finn.unleash.util.UnleashConfig;
-
 import no.finn.unleash.variant.Payload;
 import no.finn.unleash.variant.VariantDefinition;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
+import java.util.*;
+import java.util.function.BiFunction;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
@@ -56,28 +43,28 @@ public class UnleashTest {
     public void known_toogle_and_strategy_should_be_active() {
         when(toggleRepository.getToggle("test")).thenReturn(new FeatureToggle("test", true, asList(new ActivationStrategy("default", null))));
 
-        assertThat(unleash.isEnabled("test"), is(true));
+        assertThat(unleash.isEnabled("test")).isTrue();
     }
 
     @Test
     public void unknown_strategy_should_be_considered_inactive() {
         when(toggleRepository.getToggle("test")).thenReturn(new FeatureToggle("test", true, asList(new ActivationStrategy("whoot_strat", null))));
 
-        assertThat(unleash.isEnabled("test"), is(false));
+        assertThat(unleash.isEnabled("test")).isFalse();
     }
 
     @Test
     public void unknown_feature_should_be_considered_inactive() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
 
-        assertThat(unleash.isEnabled("test"), is(false));
+        assertThat(unleash.isEnabled("test")).isFalse();
     }
 
     @Test
     public void unknown_feature_should_use_default_setting() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
 
-        assertThat(unleash.isEnabled("test", true), is(true));
+        assertThat(unleash.isEnabled("test", true)).isTrue();
     }
 
     @Test
@@ -86,7 +73,7 @@ public class UnleashTest {
         BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
         when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(true);
 
-        assertThat(unleash.isEnabled("test", fallbackAction), is(true));
+        assertThat(unleash.isEnabled("test", fallbackAction)).isTrue();
         verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
     }
 
@@ -98,7 +85,7 @@ public class UnleashTest {
 
         UnleashContext context = UnleashContext.builder().userId("123").build();
 
-        assertThat(unleash.isEnabled("test", context, fallbackAction), is(true));
+        assertThat(unleash.isEnabled("test", context, fallbackAction)).isTrue();
         verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
     }
 
@@ -108,7 +95,7 @@ public class UnleashTest {
         BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
         when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(false);
 
-        assertThat(unleash.isEnabled("test", fallbackAction), is(false));
+        assertThat(unleash.isEnabled("test", fallbackAction)).isFalse();
         verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
     }
 
@@ -119,7 +106,7 @@ public class UnleashTest {
         BiFunction<String, UnleashContext, Boolean>  fallbackAction = mock(BiFunction.class);
         when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(false);
 
-		assertThat(unleash.isEnabled("test", fallbackAction), is(true));
+		assertThat(unleash.isEnabled("test", fallbackAction)).isTrue();
         verify(fallbackAction, never()).apply(anyString(), any(UnleashContext.class));
 	}
 
@@ -151,7 +138,7 @@ public class UnleashTest {
 
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test"), is(true));
+        assertThat(unleash.isEnabled("test")).isTrue();
     }
 
     @Test
@@ -167,7 +154,7 @@ public class UnleashTest {
 
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test"), is(true));
+        assertThat(unleash.isEnabled("test")).isTrue();
     }
     
     @Test
@@ -182,7 +169,7 @@ public class UnleashTest {
 
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test", context), is(true));
+        assertThat(unleash.isEnabled("test", context)).isTrue();
     }
 
     @Test
@@ -193,7 +180,7 @@ public class UnleashTest {
         Map<String, String> params = new HashMap<>();
         params.put("userIds", "123, 111, 121, 13");
 
-        assertThat(unleash.isEnabled("test", context, true), is(true));
+        assertThat(unleash.isEnabled("test", context, true)).isTrue();
     }
 
     @Test
@@ -202,7 +189,7 @@ public class UnleashTest {
         FeatureToggle featureToggle = new FeatureToggle("test", false, asList(strategy1));
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test"), is(false));
+        assertThat(unleash.isEnabled("test")).isFalse();
     }
 
     @Test
@@ -211,7 +198,7 @@ public class UnleashTest {
         FeatureToggle featureToggle = new FeatureToggle("test", false, asList(strategy1));
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(((DefaultUnleash)unleash).getFeatureToggleDefinition("test"), is(Optional.of(featureToggle)));
+        assertThat(((DefaultUnleash)unleash).getFeatureToggleDefinition("test")).hasValue(featureToggle);
     }
 
     @Test
@@ -220,14 +207,14 @@ public class UnleashTest {
         FeatureToggle featureToggle = new FeatureToggle("test", false, asList(strategy1));
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(((DefaultUnleash)unleash).getFeatureToggleDefinition("another toggleName"), is(Optional.empty()));
+        assertThat(((DefaultUnleash)unleash).getFeatureToggleDefinition("another toggleName")).isEmpty();
     }
 
     @Test
     public void get_feature_names_should_return_list_of_feature_names() {
         when(toggleRepository.getFeatureNames()).thenReturn(asList("toggleFeatureName1", "toggleFeatureName2"));
-        assertTrue(2 == unleash.getFeatureToggleNames().size());
-        assertTrue("toggleFeatureName2".equals(unleash.getFeatureToggleNames().get(1)));
+        assertThat(unleash.getFeatureToggleNames()).hasSize(2);
+        assertThat(unleash.getFeatureToggleNames().get(1)).isEqualTo("toggleFeatureName2");
     }
 
     @Test
@@ -244,10 +231,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test", context, new Variant("Chuck", "Norris", true));
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("Chuck"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("Norris"));
-        assertThat(result.isEnabled(), is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("Chuck");
+        assertThat(result.getPayload().map(Payload::getValue).get()).isEqualTo("Norris");
+        assertThat(result.isEnabled()).isTrue();
     }
 
     @Test
@@ -264,10 +251,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test", context);
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("disabled"));
-        assertThat(result.getPayload().map(Payload::getValue), is(Optional.empty()));
-        assertThat(result.isEnabled(), is(false));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("disabled");
+        assertThat(result.getPayload().map(Payload::getValue)).isEmpty();
+        assertThat(result.isEnabled()).isFalse();
     }
 
     @Test
@@ -284,10 +271,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test", context);
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("en"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("en"));
-        assertThat(result.isEnabled(), is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("en");
+        assertThat(result.getPayload().map(Payload::getValue).get()).isEqualTo("en");
+        assertThat(result.isEnabled()).isTrue();
     }
 
     @Test
@@ -304,10 +291,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test", context);
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("to"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("to"));
-        assertThat(result.isEnabled(), is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("to");
+        assertThat(result.getPayload().map(Payload::getValue).get()).isEqualTo("to");
+        assertThat(result.isEnabled()).isTrue();
     }
 
     @Test
@@ -321,10 +308,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test");
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("disabled"));
-        assertThat(result.getPayload().map(Payload::getValue), is(Optional.empty()));
-        assertThat(result.isEnabled(), is(false));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("disabled");
+        assertThat(result.getPayload().map(Payload::getValue)).isEmpty();
+        assertThat(result.isEnabled()).isFalse();
     }
 
     @Test
@@ -337,10 +324,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test", new Variant("Chuck", "Norris", true));
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("Chuck"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("Norris"));
-        assertThat(result.isEnabled(), is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("Chuck");
+        assertThat(result.getPayload().map(Payload::getValue).get()).isEqualTo("Norris");
+        assertThat(result.isEnabled()).isTrue();
     }
 
     @Test
@@ -359,10 +346,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test");
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("en"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("en"));
-        assertThat(result.isEnabled(), is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("en");
+        assertThat(result.getPayload().map(Payload::getValue).get()).isEqualTo("en");
+        assertThat(result.isEnabled()).isTrue();
     }
 
     @Test
@@ -381,10 +368,10 @@ public class UnleashTest {
 
         final Variant result = unleash.getVariant("test");
 
-        assertThat(result, is(notNullValue()));
-        assertThat(result.getName(), is("to"));
-        assertThat(result.getPayload().map(Payload::getValue).get(), is("to"));
-        assertThat(result.isEnabled(), is(true));
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("to");
+        assertThat(result.getPayload().map(Payload::getValue).get()).isEqualTo("to");
+        assertThat(result.isEnabled()).isTrue();
     }
 
     @Test
@@ -397,7 +384,7 @@ public class UnleashTest {
 
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test"), is(true));
+        assertThat(unleash.isEnabled("test")).isTrue();
     }
 
     @Test
@@ -410,7 +397,7 @@ public class UnleashTest {
 
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test"), is(false));
+        assertThat(unleash.isEnabled("test")).isFalse();
     }
 
 

--- a/src/test/java/no/finn/unleash/event/SubscriberTest.java
+++ b/src/test/java/no/finn/unleash/event/SubscriberTest.java
@@ -1,9 +1,9 @@
 package no.finn.unleash.event;
 
-import com.github.jenspiegsa.mockitoextension.ConfigureWireMock;
-import com.github.jenspiegsa.mockitoextension.InjectServer;
-import com.github.jenspiegsa.mockitoextension.WireMockExtension;
-import com.github.jenspiegsa.mockitoextension.WireMockSettings;
+import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
+import com.github.jenspiegsa.wiremockextension.InjectServer;
+import com.github.jenspiegsa.wiremockextension.WireMockExtension;
+import com.github.jenspiegsa.wiremockextension.WireMockSettings;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
 import no.finn.unleash.DefaultUnleash;

--- a/src/test/java/no/finn/unleash/integration/ClientSpecificationTest.java
+++ b/src/test/java/no/finn/unleash/integration/ClientSpecificationTest.java
@@ -14,10 +14,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.github.jenspiegsa.mockitoextension.ConfigureWireMock;
-import com.github.jenspiegsa.mockitoextension.InjectServer;
-import com.github.jenspiegsa.mockitoextension.WireMockExtension;
-import com.github.jenspiegsa.mockitoextension.WireMockSettings;
+import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
+import com.github.jenspiegsa.wiremockextension.InjectServer;
+import com.github.jenspiegsa.wiremockextension.WireMockExtension;
+import com.github.jenspiegsa.wiremockextension.WireMockSettings;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
 import com.google.gson.Gson;

--- a/src/test/java/no/finn/unleash/metric/UnleashMetricServiceImplTest.java
+++ b/src/test/java/no/finn/unleash/metric/UnleashMetricServiceImplTest.java
@@ -2,22 +2,14 @@ package no.finn.unleash.metric;
 
 import no.finn.unleash.util.UnleashConfig;
 import no.finn.unleash.util.UnleashScheduledExecutor;
-import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 public class UnleashMetricServiceImplTest {
 
@@ -58,12 +50,11 @@ public class UnleashMetricServiceImplTest {
         ArgumentCaptor<ClientRegistration> argument = ArgumentCaptor.forClass(ClientRegistration.class);
 
         verify(sender).registerClient(argument.capture());
-        assertThat(argument.getValue().getAppName(), is(config.getAppName()));
-        assertThat(argument.getValue().getInstanceId(), is(config.getInstanceId()));
-        assertThat(argument.getValue().getStarted(), is(not(IsNull.nullValue())));
-        assertThat(argument.getValue().getStrategies().size(), is(2));
-        assertTrue(argument.getValue().getStrategies().contains("default"));
-        assertTrue(argument.getValue().getStrategies().contains("custom"));
+        assertThat(argument.getValue().getAppName()).isEqualTo(config.getAppName());
+        assertThat(argument.getValue().getInstanceId()).isEqualTo(config.getInstanceId());
+        assertThat(argument.getValue().getStarted()).isNotNull();
+        assertThat(argument.getValue().getStrategies()).hasSize(2);
+        assertThat(argument.getValue().getStrategies()).contains("default", "custom");
     }
 
 
@@ -119,13 +110,13 @@ public class UnleashMetricServiceImplTest {
         ClientMetrics clientMetrics = clientMetricsArgumentCaptor.getValue();
         MetricsBucket bucket = clientMetricsArgumentCaptor.getValue().getBucket();
 
-        assertThat(clientMetrics.getAppName(), is(config.getAppName()));
-        assertThat(clientMetrics.getInstanceId(), is(config.getInstanceId()));
-        assertNotNull(bucket.getStart());
-        assertNotNull(bucket.getStop());
-        assertThat(bucket.getToggles().size(), is(2));
-        assertThat(bucket.getToggles().get("someToggle").getYes(), is(2l));
-        assertThat(bucket.getToggles().get("someToggle").getNo(), is(1l));
+        assertThat(clientMetrics.getAppName()).isEqualTo(config.getAppName());
+        assertThat(clientMetrics.getInstanceId()).isEqualTo(config.getInstanceId());
+        assertThat(bucket.getStart()).isNotNull();
+        assertThat(bucket.getStop()).isNotNull();
+        assertThat(bucket.getToggles()).hasSize(2);
+        assertThat(bucket.getToggles().get("someToggle").getYes()).isEqualTo(2l);
+        assertThat(bucket.getToggles().get("someToggle").getNo()).isEqualTo(1l);
     }
 
     @Test
@@ -159,16 +150,16 @@ public class UnleashMetricServiceImplTest {
         ClientMetrics clientMetrics = clientMetricsArgumentCaptor.getValue();
         MetricsBucket bucket = clientMetricsArgumentCaptor.getValue().getBucket();
 
-        assertThat(clientMetrics.getAppName(), is(config.getAppName()));
-        assertThat(clientMetrics.getInstanceId(), is(config.getInstanceId()));
-        assertNotNull(bucket.getStart());
-        assertNotNull(bucket.getStop());
-        assertThat(bucket.getToggles().size(), is(1));
-        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v1").longValue(), is(3l));
-        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v2").longValue(), is(1l));
-        assertThat(bucket.getToggles().get("someToggle").getVariants().get("disabled").longValue(), is(1l));
-        assertThat(bucket.getToggles().get("someToggle").getYes(), is(0l));
-        assertThat(bucket.getToggles().get("someToggle").getNo(), is(0l));
+        assertThat(clientMetrics.getAppName()).isEqualTo(config.getAppName());
+        assertThat(clientMetrics.getInstanceId()).isEqualTo(config.getInstanceId());
+        assertThat(bucket.getStart()).isNotNull();
+        assertThat(bucket.getStop()).isNotNull();
+        assertThat(bucket.getToggles()).hasSize(1);
+        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v1").longValue()).isEqualTo(3l);
+        assertThat(bucket.getToggles().get("someToggle").getVariants().get("v2").longValue()).isEqualTo(1l);
+        assertThat(bucket.getToggles().get("someToggle").getVariants().get("disabled").longValue()).isEqualTo(1l);
+        assertThat(bucket.getToggles().get("someToggle").getYes()).isEqualTo(0l);
+        assertThat(bucket.getToggles().get("someToggle").getNo()).isEqualTo(0l);
     }
 
 }

--- a/src/test/java/no/finn/unleash/metric/UnleashMetricsSenderTest.java
+++ b/src/test/java/no/finn/unleash/metric/UnleashMetricsSenderTest.java
@@ -1,9 +1,9 @@
 package no.finn.unleash.metric;
 
-import com.github.jenspiegsa.mockitoextension.ConfigureWireMock;
-import com.github.jenspiegsa.mockitoextension.InjectServer;
-import com.github.jenspiegsa.mockitoextension.WireMockExtension;
-import com.github.jenspiegsa.mockitoextension.WireMockSettings;
+import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
+import com.github.jenspiegsa.wiremockextension.InjectServer;
+import com.github.jenspiegsa.wiremockextension.WireMockExtension;
+import com.github.jenspiegsa.wiremockextension.WireMockSettings;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
 import no.finn.unleash.util.UnleashConfig;

--- a/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
+++ b/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
@@ -1,9 +1,9 @@
 package no.finn.unleash.repository;
 
-import com.github.jenspiegsa.mockitoextension.ConfigureWireMock;
-import com.github.jenspiegsa.mockitoextension.InjectServer;
-import com.github.jenspiegsa.mockitoextension.WireMockExtension;
-import com.github.jenspiegsa.mockitoextension.WireMockSettings;
+import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
+import com.github.jenspiegsa.wiremockextension.InjectServer;
+import com.github.jenspiegsa.wiremockextension.WireMockExtension;
+import com.github.jenspiegsa.wiremockextension.WireMockSettings;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.Options;
 import no.finn.unleash.FeatureToggle;
@@ -19,10 +19,7 @@ import java.net.URISyntaxException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(WireMockExtension.class)
 @WireMockSettings(failOnUnmatchedRequests = false)
@@ -69,7 +66,7 @@ public class HttpToggleFetcherTest {
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
         FeatureToggle featureX = response.getToggleCollection().getToggle("featureX");
 
-        assertTrue(featureX.isEnabled());
+        assertThat(featureX.isEnabled()).isTrue();
 
         verify(getRequestedFor(urlMatching("/api/client/features"))
                 .withHeader("Content-Type", matching("application/json")));
@@ -90,7 +87,7 @@ public class HttpToggleFetcherTest {
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
         FeatureToggle featureX = response.getToggleCollection().getToggle("featureX");
 
-        assertTrue(featureX.isEnabled());
+        assertThat(featureX.isEnabled()).isTrue();
 
         verify(getRequestedFor(urlMatching("/api/client/features"))
                 .withHeader("Content-Type", matching("application/json")));
@@ -111,8 +108,8 @@ public class HttpToggleFetcherTest {
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
         FeatureToggle featureX = response.getToggleCollection().getToggle("Test.variants");
 
-        assertTrue(featureX.isEnabled());
-        assertThat(featureX.getVariants().get(0).getName(), is("variant1"));
+        assertThat(featureX.isEnabled()).isTrue();
+        assertThat(featureX.getVariants().get(0).getName()).isEqualTo("variant1");
 
         verify(getRequestedFor(urlMatching("/api/client/features"))
                 .withHeader("Content-Type", matching("application/json")));
@@ -144,8 +141,8 @@ public class HttpToggleFetcherTest {
         FeatureToggleResponse response1 = httpToggleFetcher.fetchToggles();
         FeatureToggleResponse response2 = httpToggleFetcher.fetchToggles();
 
-        assertEquals(response1.getStatus(), FeatureToggleResponse.Status.CHANGED);
-        assertEquals(response2.getStatus(), FeatureToggleResponse.Status.NOT_CHANGED);
+        assertThat(response1.getStatus()).isEqualTo(FeatureToggleResponse.Status.CHANGED);
+        assertThat(response2.getStatus()).isEqualTo(FeatureToggleResponse.Status.NOT_CHANGED);
     }
 
     @Test
@@ -198,8 +195,7 @@ public class HttpToggleFetcherTest {
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
-        assertEquals(response.getStatus(), FeatureToggleResponse.Status.NOT_CHANGED,
-                "Should return status NOT_CHANGED");
+        assertThat(response.getStatus()).isEqualTo(FeatureToggleResponse.Status.NOT_CHANGED);
 
         verify(getRequestedFor(urlMatching("/api/client/features"))
                 .withHeader("Content-Type", matching("application/json")));
@@ -224,8 +220,7 @@ public class HttpToggleFetcherTest {
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
-        assertEquals(response.getStatus(), FeatureToggleResponse.Status.CHANGED,
-                "Should return status CHANGED");
+        assertThat(response.getStatus()).isEqualTo(FeatureToggleResponse.Status.CHANGED);
 
         verify(getRequestedFor(urlMatching("/api/client/features"))
                 .withHeader("Content-Type", matching("application/json")));
@@ -246,10 +241,8 @@ public class HttpToggleFetcherTest {
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
-        assertEquals(response.getStatus(), FeatureToggleResponse.Status.UNAVAILABLE,
-                "Should return status UNAVAILABLE");
-        assertEquals(response.getHttpStatusCode(), httpCode,
-                "Should return correct status code");
+        assertThat(response.getStatus()).isEqualTo(FeatureToggleResponse.Status.UNAVAILABLE);
+        assertThat(response.getHttpStatusCode()).isEqualTo(httpCode);
 
         verify(getRequestedFor(urlMatching("/api/client/features"))
                 .withHeader("Content-Type", matching("application/json")));
@@ -287,7 +280,7 @@ public class HttpToggleFetcherTest {
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
-        assertThat(response.getLocation(), is("https://unleash.com"));
+        assertThat(response.getLocation()).isEqualTo("https://unleash.com");
 
     }
 

--- a/src/test/java/no/finn/unleash/repository/JsonFeatureToggleParserTest.java
+++ b/src/test/java/no/finn/unleash/repository/JsonFeatureToggleParserTest.java
@@ -3,15 +3,10 @@ package no.finn.unleash.repository;
 import no.finn.unleash.FeatureToggle;
 import org.junit.jupiter.api.Test;
 
-
 import java.io.*;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.AdditionalMatchers.not;
 
 public class JsonFeatureToggleParserTest {
 
@@ -20,8 +15,8 @@ public class JsonFeatureToggleParserTest {
         Reader content = getFileReader("/features-v1.json");
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
 
-        assertThat(toggleCollection.getFeatures().size(), is(3));
-        assertThat(toggleCollection.getToggle("featureX").isEnabled(), is(true));
+        assertThat(toggleCollection.getFeatures()).hasSize(3);
+        assertThat(toggleCollection.getToggle("featureX").isEnabled()).isTrue();
     }
 
     @Test
@@ -29,8 +24,8 @@ public class JsonFeatureToggleParserTest {
         Reader content = getFileReader("/features-v0.json");
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
 
-        assertThat(toggleCollection.getFeatures().size(), is(3));
-        assertThat(toggleCollection.getToggle("featureX").isEnabled(), is(true));
+        assertThat(toggleCollection.getFeatures()).hasSize(3);
+        assertThat(toggleCollection.getToggle("featureX").isEnabled()).isTrue();
     }
 
     @Test
@@ -39,9 +34,9 @@ public class JsonFeatureToggleParserTest {
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
         FeatureToggle featureY = toggleCollection.getToggle("featureY");
 
-        assertThat(featureY.getStrategies().size(), is(1));
-        assertThat(featureY.getStrategies().get(0).getName(), is("baz"));
-        assertThat(featureY.getStrategies().get(0).getParameters().get("foo"), is("bar"));
+        assertThat(featureY.getStrategies()).hasSize(1);
+        assertThat(featureY.getStrategies().get(0).getName()).isEqualTo("baz");
+        assertThat(featureY.getStrategies().get(0).getParameters().get("foo")).isEqualTo("bar");
     }
 
     @Test
@@ -50,10 +45,10 @@ public class JsonFeatureToggleParserTest {
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
         FeatureToggle featureY = toggleCollection.getToggle("featureY");
 
-        assertThat(featureY.isEnabled(), is(false));
-        assertThat(featureY.getStrategies().size(), is(1));
-        assertThat(featureY.getStrategies().get(0).getName(), is("baz"));
-        assertThat(featureY.getStrategies().get(0).getParameters().get("foo"), is("bar"));
+        assertThat(featureY.isEnabled()).isFalse();
+        assertThat(featureY.getStrategies()).hasSize(1);
+        assertThat(featureY.getStrategies().get(0).getName()).isEqualTo("baz");
+        assertThat(featureY.getStrategies().get(0).getParameters().get("foo")).isEqualTo("bar");
     }
 
     @Test
@@ -62,9 +57,9 @@ public class JsonFeatureToggleParserTest {
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
         FeatureToggle feature = toggleCollection.getToggle("featureZ");
 
-        assertThat(feature.getStrategies().size(), is(2));
-        assertThat(feature.getStrategies().get(1).getName(), is("hola"));
-        assertThat(feature.getStrategies().get(1).getParameters().get("name"), is("val"));
+        assertThat(feature.getStrategies()).hasSize(2);
+        assertThat(feature.getStrategies().get(1).getName()).isEqualTo("hola");
+        assertThat(feature.getStrategies().get(1).getParameters().get("name")).isEqualTo("val");
     }
 
     @Test
@@ -84,7 +79,7 @@ public class JsonFeatureToggleParserTest {
         Reader content = getFileReader("/features-v1-empty.json");
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
 
-        assertThat(toggleCollection.getFeatures().size(), is(0));
+        assertThat(toggleCollection.getFeatures()).hasSize(0);
     }
 
     @Test
@@ -93,10 +88,10 @@ public class JsonFeatureToggleParserTest {
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
         FeatureToggle featureY = toggleCollection.getToggle("featureY");
 
-        assertThat(toggleCollection.getFeatures().size(), is(3));
-        assertThat(featureY.getStrategies().size(), is(1));
-        assertThat(featureY.getStrategies().get(0).getName(), is("baz"));
-        assertThat(featureY.getStrategies().get(0).getParameters().get("foo"), is("bar"));
+        assertThat(toggleCollection.getFeatures()).hasSize(3);
+        assertThat(featureY.getStrategies()).hasSize(1);
+        assertThat(featureY.getStrategies().get(0).getName()).isEqualTo("baz");
+        assertThat(featureY.getStrategies().get(0).getParameters().get("foo")).isEqualTo("bar");
     }
 
     @Test
@@ -104,17 +99,17 @@ public class JsonFeatureToggleParserTest {
         Reader content = getFileReader("/features-v1-with-variants.json");
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
 
-        assertThat(toggleCollection.getFeatures().size(), is(2));
-        assertThat(toggleCollection.getToggle("Test.old").isEnabled(), is(true));
-        assertThat(toggleCollection.getToggle("Test.variants").isEnabled(), is(true));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants(), is(notNullValue()));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().size(), is(2));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(0).getName(), is("variant1"));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(1).getName(), is("variant2"));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(0).getWeight(), is(50));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(1).getWeight(), is(50));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(0).getPayload(), is(nullValue()));
-        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(1).getPayload(), is(nullValue()));
+        assertThat(toggleCollection.getFeatures()).hasSize(2);
+        assertThat(toggleCollection.getToggle("Test.old").isEnabled()).isTrue();
+        assertThat(toggleCollection.getToggle("Test.variants").isEnabled()).isTrue();
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants()).isNotNull();
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants()).hasSize(2);
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(0).getName()).isEqualTo("variant1");
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(1).getName()).isEqualTo("variant2");
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(0).getWeight()).isEqualTo(50);
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(1).getWeight()).isEqualTo(50);
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(0).getPayload()).isNull();
+        assertThat(toggleCollection.getToggle("Test.variants").getVariants().get(1).getPayload()).isNull();
     }
 
     private Reader getFileReader(String filename) throws IOException {

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutSessionIdStrategyTest.java
@@ -11,9 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,13 +41,13 @@ public class GradualRolloutSessionIdStrategyTest {
     @Test
     public void should_have_a_name() {
         GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
-        assertThat(gradualRolloutStrategy.getName(), is("gradualRolloutSessionId"));
+        assertThat(gradualRolloutStrategy.getName()).isEqualTo("gradualRolloutSessionId");
     }
 
     @Test
     public void should_require_context() {
         GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
-        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>()), is(false));
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>())).isFalse();
     }
 
     @Test
@@ -57,7 +55,7 @@ public class GradualRolloutSessionIdStrategyTest {
         UnleashContext context = UnleashContext.builder().build();
         GradualRolloutSessionIdStrategy gradualRolloutStrategy = new GradualRolloutSessionIdStrategy();
 
-        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>(), context), is(false));
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>(), context)).isFalse();
     }
 
     @Test
@@ -70,11 +68,7 @@ public class GradualRolloutSessionIdStrategyTest {
 
         for (int i = 0; i < 10; i++) {
             boolean subsequentRunResult = gradualRolloutStrategy.isEnabled(params, context);
-            assertThat(
-                    "loginId will return same result when unchanged parameters",
-                    firstRunResult,
-                    is(equalTo(subsequentRunResult))
-            );
+            assertThat(firstRunResult).isEqualTo(subsequentRunResult).withFailMessage("loginId should return same result when unchanged parameters");
         }
     }
 
@@ -86,7 +80,7 @@ public class GradualRolloutSessionIdStrategyTest {
         Map<String, String> params = buildParams(100, "innfinn");
         boolean result = gradualRolloutStrategy.isEnabled(params, context);
 
-        assertThat(result, is(true));
+        assertThat(result).isTrue();
     }
 
 

--- a/src/test/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/GradualRolloutUserIdStrategyTest.java
@@ -7,13 +7,12 @@ import java.util.Random;
 
 import com.google.common.collect.ImmutableList;
 import no.finn.unleash.UnleashContext;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,13 +42,13 @@ public class GradualRolloutUserIdStrategyTest {
     @Test
     public void should_have_a_name() {
         GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
-        assertThat(gradualRolloutStrategy.getName(), is("gradualRolloutUserId"));
+        assertThat(gradualRolloutStrategy.getName()).isEqualTo("gradualRolloutUserId");
     }
 
     @Test
     public void should_require_context() {
         GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
-        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>()), is(false));
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>())).isFalse();
     }
 
     @Test
@@ -57,7 +56,7 @@ public class GradualRolloutUserIdStrategyTest {
         UnleashContext context = UnleashContext.builder().build();
         GradualRolloutUserIdStrategy gradualRolloutStrategy = new GradualRolloutUserIdStrategy();
 
-        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>(), context), is(false));
+        assertThat(gradualRolloutStrategy.isEnabled(new HashMap<>(), context)).isFalse();
     }
 
     @Test
@@ -70,11 +69,7 @@ public class GradualRolloutUserIdStrategyTest {
 
         for (int i = 0; i < 10; i++) {
             boolean subsequentRunResult = gradualRolloutStrategy.isEnabled(params, context);
-            assertThat(
-                    "loginId will return same result when unchanged parameters",
-                    firstRunResult,
-                    is(equalTo(subsequentRunResult))
-            );
+            assertThat(firstRunResult).isEqualTo(subsequentRunResult);
         }
     }
 
@@ -86,7 +81,7 @@ public class GradualRolloutUserIdStrategyTest {
         Map<String, String> params = buildParams(100, "innfinn");
         boolean result = gradualRolloutStrategy.isEnabled(params, context);
 
-        assertThat(result, is(true));
+        assertThat(result).isTrue();
     }
 
 
@@ -97,7 +92,6 @@ public class GradualRolloutUserIdStrategyTest {
 
         Map<String, String> params = buildParams(0, "innfinn");
         boolean actual = gradualRolloutStrategy.isEnabled(params, context);
-
         assertFalse(actual, "should not be enabled when 0% rollout");
     }
 
@@ -140,11 +134,7 @@ public class GradualRolloutUserIdStrategyTest {
 
         double actualPercentage = ((double) enabledCount / (double) rounds) * 100.0;
 
-        assertTrue((percentage-1) < actualPercentage,
-                "Expected " + percentage + "%, but was "+ actualPercentage + "%");
-
-        assertTrue((percentage+1) > actualPercentage,
-                "Expected " + percentage + "%, but was "+ actualPercentage + "%");
+        assertThat(actualPercentage).isEqualTo(percentage, Offset.strictOffset(1.0d));
     }
 
 

--- a/src/test/java/no/finn/unleash/strategy/RemoteAddressStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/RemoteAddressStrategyTest.java
@@ -15,8 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class RemoteAddressStrategyTest {
     private static final String FIRST_IPV4 = "127.0.0.1";
@@ -83,7 +82,7 @@ class RemoteAddressStrategyTest {
 
     @Test
     void should_have_a_name() {
-        assertThat(strategy.getName(), is("remoteAddress"));
+        assertThat(strategy.getName()).isEqualTo("remoteAddress");
     }
 
     @ParameterizedTest
@@ -92,7 +91,7 @@ class RemoteAddressStrategyTest {
         UnleashContext context = UnleashContext.builder().remoteAddress(actualIp).build();
         Map<String, String> parameters = setupParameterMap(parameterString);
 
-        assertThat(strategy.isEnabled(parameters, context), is(expected));
+        assertThat(strategy.isEnabled(parameters, context)).isEqualTo(expected);
     }
 
     private Map<String, String> setupParameterMap(String ipString) {

--- a/src/test/java/no/finn/unleash/strategy/UserWithIdStrategyTest.java
+++ b/src/test/java/no/finn/unleash/strategy/UserWithIdStrategyTest.java
@@ -6,9 +6,8 @@ import no.finn.unleash.UnleashContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UserWithIdStrategyTest {
@@ -21,7 +20,7 @@ public class UserWithIdStrategyTest {
 
     @Test
     public void should_have_expected_strategy_name() {
-        assertThat(strategy.getName(), is("userWithId"));
+        assertThat(strategy.getName()).isEqualTo("userWithId");
 
     }
 

--- a/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashConfigTest.java
@@ -5,6 +5,7 @@ import no.finn.unleash.DefaultCustomHttpHeadersProviderImpl;
 import no.finn.unleash.util.UnleashConfig.ProxyAuthenticator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -13,14 +14,10 @@ import java.net.*;
 import java.net.Authenticator.RequestorType;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-
-import org.mockito.Mockito;
 
 import static no.finn.unleash.util.UnleashConfig.UNLEASH_APP_NAME_HEADER;
 import static no.finn.unleash.util.UnleashConfig.UNLEASH_INSTANCE_ID_HEADER;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -52,9 +49,9 @@ public class UnleashConfigTest {
                 .unleashAPI("http://unleash.org")
                 .build();
 
-        assertThat(config.getAppName(), is("my-app"));
-        assertThat(config.getInstanceId(), is("my-instance-1"));
-        assertThat(config.getUnleashAPI(), is(URI.create("http://unleash.org")));
+        assertThat(config.getAppName()).isEqualTo("my-app");
+        assertThat(config.getInstanceId()).isEqualTo("my-instance-1");
+        assertThat(config.getUnleashAPI()).isEqualTo(URI.create("http://unleash.org"));
     }
 
     @Test
@@ -64,8 +61,8 @@ public class UnleashConfigTest {
                 .unleashAPI("http://unleash.org")
                 .build();
 
-        assertThat(config.getAppName(), is("my-app"));
-        assertThat(config.getBackupFile(), is(System.getProperty("java.io.tmpdir") + File.separatorChar + "unleash-my-app-repo.json"));
+        assertThat(config.getAppName()).isEqualTo("my-app");
+        assertThat(config.getBackupFile()).isEqualTo(System.getProperty("java.io.tmpdir") + File.separatorChar + "unleash-my-app-repo.json");
     }
 
     @Test
@@ -76,8 +73,8 @@ public class UnleashConfigTest {
                 .unleashAPI("http://unleash.org")
                 .build();
 
-        assertThat(config.getAppName(), is("my-app"));
-        assertThat(config.getBackupFile(), is("/test/unleash-backup.json"));
+        assertThat(config.getAppName()).isEqualTo("my-app");
+        assertThat(config.getBackupFile()).isEqualTo("/test/unleash-backup.json");
     }
 
     @Test
@@ -87,7 +84,7 @@ public class UnleashConfigTest {
                 .unleashAPI("http://unleash.org")
                 .build();
 
-        assertThat(config.getSdkVersion(), is("unleash-client-java:development"));
+        assertThat(config.getSdkVersion()).isEqualTo("unleash-client-java:development");
     }
 
     @Test
@@ -97,7 +94,7 @@ public class UnleashConfigTest {
                 .unleashAPI("http://unleash.org")
                 .build();
 
-        assertThat(config.getEnvironment(), is("default"));
+        assertThat(config.getEnvironment()).isEqualTo("default");
     }
 
     @Test
@@ -109,7 +106,7 @@ public class UnleashConfigTest {
                 .unleashAPI("http://unleash.org")
                 .build();
 
-        assertThat(config.getEnvironment(), is(env));
+        assertThat(config.getEnvironment()).isEqualTo(env);
     }
 
     @Test
@@ -128,9 +125,9 @@ public class UnleashConfigTest {
         HttpURLConnection connection = (HttpURLConnection) someUrl.openConnection();
 
         UnleashConfig.setRequestProperties(connection, unleashConfig);
-        assertThat(connection.getRequestProperty(UNLEASH_APP_NAME_HEADER), is(appName));
-        assertThat(connection.getRequestProperty(UNLEASH_INSTANCE_ID_HEADER), is(instanceId));
-        assertThat(connection.getRequestProperty("User-Agent"), is(appName));
+        assertThat(connection.getRequestProperty(UNLEASH_APP_NAME_HEADER)).isEqualTo(appName);
+        assertThat(connection.getRequestProperty(UNLEASH_INSTANCE_ID_HEADER)).isEqualTo(instanceId);
+        assertThat(connection.getRequestProperty("User-Agent")).isEqualTo(appName);
     }
 
     @Test
@@ -150,7 +147,7 @@ public class UnleashConfigTest {
         HttpURLConnection connection = (HttpURLConnection) someUrl.openConnection();
 
         UnleashConfig.setRequestProperties(connection, unleashConfig);
-        assertThat(connection.getRequestProperty(headerName), is(headerValue));
+        assertThat(connection.getRequestProperty(headerName)).isEqualTo(headerValue);
     }
 
     @Test
@@ -174,7 +171,7 @@ public class UnleashConfigTest {
         UnleashConfig.setRequestProperties(connection, unleashConfig);
 
         for (String key: result.keySet()) {
-            assertThat(connection.getRequestProperty(key), is(result.get(key)));
+            assertThat(connection.getRequestProperty(key)).isEqualTo(result.get(key));
         }
     }
 
@@ -231,8 +228,8 @@ public class UnleashConfigTest {
 
         PasswordAuthentication passwordAuthentication = proxyAuthenticator.getPasswordAuthentication();
 
-        assertThat(passwordAuthentication.getUserName(), is(proxyUser));
-        assertThat(new String(passwordAuthentication.getPassword()), is(proxyPassword));
-        assertThat(config.isProxyAuthenticationByJvmProperties(), is(true));
+        assertThat(passwordAuthentication.getUserName()).isEqualTo(proxyUser);
+        assertThat(new String(passwordAuthentication.getPassword())).isEqualTo(proxyPassword);
+        assertThat(config.isProxyAuthenticationByJvmProperties()).isEqualTo(true);
     }
 }

--- a/src/test/java/no/finn/unleash/util/UnleashURLsTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashURLsTest.java
@@ -4,8 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UnleashURLsTest {
@@ -14,25 +13,25 @@ public class UnleashURLsTest {
     @Test
     public void should_handle_additional_slash() {
         UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
-        assertThat(urls.getFetchTogglesURL().toString(), is("http://unleash.com/api/client/features"));
+        assertThat(urls.getFetchTogglesURL().toString()).isEqualTo("http://unleash.com/api/client/features");
     }
 
     @Test
     public void should_set_correct_client_register_url() {
         UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
-        assertThat(urls.getClientRegisterURL().toString(), is("http://unleash.com/api/client/register"));
+        assertThat(urls.getClientRegisterURL().toString()).isEqualTo("http://unleash.com/api/client/register");
     }
 
     @Test
     public void should_set_correct_client_metrics_url() {
         UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
-        assertThat(urls.getClientMetricsURL().toString(), is("http://unleash.com/api/client/metrics"));
+        assertThat(urls.getClientMetricsURL().toString()).isEqualTo("http://unleash.com/api/client/metrics");
     }
 
     @Test
     public void should_set_correct_fetch_url() {
         UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
-        assertThat(urls.getFetchTogglesURL().toString(), is("http://unleash.com/api/client/features"));
+        assertThat(urls.getFetchTogglesURL().toString()).isEqualTo("http://unleash.com/api/client/features");
     }
 
     @Test()

--- a/src/test/java/no/finn/unleash/variant/VariantUtilTest.java
+++ b/src/test/java/no/finn/unleash/variant/VariantUtilTest.java
@@ -1,18 +1,16 @@
 package no.finn.unleash.variant;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import no.finn.unleash.ActivationStrategy;
 import no.finn.unleash.FeatureToggle;
 import no.finn.unleash.UnleashContext;
 import no.finn.unleash.Variant;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 import static java.util.Arrays.asList;
 import static no.finn.unleash.Variant.DISABLED_VARIANT;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class VariantUtilTest {
@@ -26,7 +24,7 @@ public class VariantUtilTest {
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
 
-        assertThat(variant, is(DISABLED_VARIANT));
+        assertThat(variant).isEqualTo(DISABLED_VARIANT);
     }
 
     @Test
@@ -44,9 +42,9 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v1.getName()));
-        assertThat(variant.getPayload().get(), is(v1.getPayload()));
-        assertThat(variant.isEnabled(), is(true));
+        assertThat(variant.getName()).isEqualTo(v1.getName());
+        assertThat(variant.getPayload()).hasValue(v1.getPayload());
+        assertThat(variant.isEnabled()).isTrue();
     }
 
     @Test
@@ -64,7 +62,7 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v2.getName()));
+        assertThat(variant.getName()).isEqualTo(v2.getName());
     }
 
     @Test
@@ -82,7 +80,7 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v3.getName()));
+        assertThat(variant.getName()).isEqualTo(v3.getName());
     }
 
     @Test
@@ -101,7 +99,7 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v2.getName()));
+        assertThat(variant.getName()).isEqualTo(v2.getName());
     }
 
     @Test
@@ -120,9 +118,9 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v3.getName()));
-        assertThat(variant.getPayload().get(), is(v3.getPayload()));
-        assertThat(variant.isEnabled(), is(true));
+        assertThat(variant.getName()).isEqualTo(v3.getName());
+        assertThat(variant.getPayload()).hasValue(v3.getPayload());
+        assertThat(variant.isEnabled()).isTrue();
     }
 
     @Test
@@ -144,7 +142,7 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v2.getName()));
+        assertThat(variant.getName()).isEqualTo(v2.getName());
     }
 
     @Test
@@ -170,6 +168,6 @@ public class VariantUtilTest {
 
         Variant variant = VariantUtil.selectVariant(toggle, context, DISABLED_VARIANT);
 
-        assertThat(variant.getName(), is(v2.getName()));
+        assertThat(variant.getName()).isEqualTo(v2.getName());
     }
 }


### PR DESCRIPTION
To simplify bringing your own logging framework to unleash, this switches unleash's dependency to be on slf4j-api, making us compatible with any framework with an implementation of slf4j (Logback, Log4j, Log4j2 etc.)

In addition this PR completes the migration to assertj and junit5; thereby eliminating our dependency on junit4 and hamcrest.

As well as configuring github actions for building and doing some much needed maintenance on dependencies.