### PR TITLE
Add UnleashConfig field to ClientRegistration events

### DIFF
--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -9,6 +9,7 @@ import java.util.function.BiFunction;
 
 import no.finn.unleash.event.EventDispatcher;
 import no.finn.unleash.event.ToggleEvaluated;
+import no.finn.unleash.event.UnleashConfigured;
 import no.finn.unleash.metric.UnleashMetricService;
 import no.finn.unleash.metric.UnleashMetricServiceImpl;
 import no.finn.unleash.repository.FeatureToggleRepository;
@@ -61,6 +62,7 @@ public final class DefaultUnleash implements Unleash {
         this.eventDispatcher = new EventDispatcher(unleashConfig);
         this.metricService = new UnleashMetricServiceImpl(unleashConfig, unleashConfig.getScheduledExecutor());
         metricService.register(strategyMap.keySet());
+        this.eventDispatcher.dispatch(new UnleashConfigured(unleashConfig));
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/event/UnleashConfigured.java
+++ b/src/main/java/no/finn/unleash/event/UnleashConfigured.java
@@ -1,0 +1,17 @@
+package no.finn.unleash.event;
+
+import no.finn.unleash.util.UnleashConfig;
+
+public class UnleashConfigured implements UnleashEvent {
+    private final UnleashConfig config;
+    public UnleashConfigured(UnleashConfig config) {
+        this.config = config;
+    }
+    public UnleashConfig getConfig() {
+        return config;
+    }
+    @Override
+    public void publishTo(UnleashSubscriber unleashSubscriber) {
+        unleashSubscriber.onConfigured(this);
+    }
+}

--- a/src/main/java/no/finn/unleash/event/UnleashSubscriber.java
+++ b/src/main/java/no/finn/unleash/event/UnleashSubscriber.java
@@ -21,5 +21,6 @@ public interface UnleashSubscriber {
     default void clientRegistered(ClientRegistration clientRegistration) { }
     default void togglesBackedUp(ToggleCollection toggleCollection) { }
     default void toggleBackupRestored(ToggleCollection toggleCollection) { }
+    default void onConfigured(UnleashConfigured config) {}
 
 }

--- a/src/main/java/no/finn/unleash/metric/ClientRegistration.java
+++ b/src/main/java/no/finn/unleash/metric/ClientRegistration.java
@@ -16,6 +16,7 @@ public class ClientRegistration implements UnleashEvent {
     private final long interval;
     private final String environment;
 
+
     ClientRegistration(UnleashConfig config, LocalDateTime started, Set<String> strategies) {
         this.environment = config.getEnvironment();
         this.appName = config.getAppName();
@@ -46,7 +47,7 @@ public class ClientRegistration implements UnleashEvent {
         return started;
     }
 
-    public long getInterval() {
+    public long getSendMetricsInterval() {
         return interval;
     }
 
@@ -65,9 +66,10 @@ public class ClientRegistration implements UnleashEvent {
                 + " appName=" + appName
                 + " instanceId=" + instanceId
                 + " sdkVersion=" + sdkVersion
-                + " started=" + sdkVersion
-                + " interval=" + sdkVersion
+                + " started=" + started
+                + " interval=" + interval
                 + " strategies=" + strategies
+                + " environment=" + environment
                 ;
     }
 }

--- a/src/main/java/no/finn/unleash/repository/FeatureToggleRepository.java
+++ b/src/main/java/no/finn/unleash/repository/FeatureToggleRepository.java
@@ -1,6 +1,7 @@
 package no.finn.unleash.repository;
 
 import no.finn.unleash.event.EventDispatcher;
+import no.finn.unleash.event.UnleashConfigured;
 import no.finn.unleash.event.UnleashReady;
 import no.finn.unleash.util.UnleashConfig;
 import no.finn.unleash.util.UnleashScheduledExecutor;
@@ -42,7 +43,6 @@ public final class FeatureToggleRepository implements ToggleRepository {
         this.toggleBackupHandler = toggleBackupHandler;
         this.toggleFetcher = toggleFetcher;
         this.eventDispatcher = new EventDispatcher(unleashConfig);
-
         toggleCollection = toggleBackupHandler.read();
 
         if(unleashConfig.isSynchronousFetchOnInitialisation()){

--- a/src/test/java/no/finn/unleash/event/SubscriberTest.java
+++ b/src/test/java/no/finn/unleash/event/SubscriberTest.java
@@ -34,7 +34,7 @@ public class SubscriberTest {
     @InjectServer
     WireMockServer serverMock;
 
-    private TestSubscriber testSubscriber = new TestSubscriber();
+    private final TestSubscriber testSubscriber = new TestSubscriber();
     private UnleashConfig unleashConfig;
 
     @BeforeEach
@@ -43,7 +43,7 @@ public class SubscriberTest {
                 .appName(SubscriberTest.class.getSimpleName())
                 .instanceId(SubscriberTest.class.getSimpleName())
                 .synchronousFetchOnInitialisation(true)
-                .unleashAPI("http://localhost:" + serverMock.port())
+                .unleashAPI(serverMock.baseUrl())
                 .subscriber(testSubscriber)
                 .scheduledExecutor(new SynchronousTestExecutor())
                 .build();
@@ -64,7 +64,8 @@ public class SubscriberTest {
         assertThat(testSubscriber.toggleEnabled).isFalse();
         assertThat(testSubscriber.errors).hasSize(2);
 
-        assertThat(testSubscriber.events).hasSize(3 // feature evaluations
+        assertThat(testSubscriber.events).hasSize(1 // UnleashConfigured event
+                + 3 // feature evaluations
                 + 2 // toggle fetches
                 + 1 // unleash ready
                 + 1 // client registration

--- a/src/test/java/no/finn/unleash/repository/FeatureToggleRepositoryTest.java
+++ b/src/test/java/no/finn/unleash/repository/FeatureToggleRepositoryTest.java
@@ -11,6 +11,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
I'm really unsure about the fields on the class, I think it still makes sense to keep the fields we get straight from the config, because that adds value to the serialized version of the class (Gson serializes the fields to a json object)

I needed to add an exclusion strategy to prevent serialization of the config field because UnleashConfig apparently has some recursive fields, because it blew my stack away while running the client specification tests

fixes: #86