### PR TITLE
Add Nullable annotations where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat: add support for filtering on project (Enterprise only)
 - fix: BREAKING CHANGE UnleashConfig constructor is now private.
   Use UnleashConfig.Builder to get instance of UnleashConfig
+- feat: Add annotations to indicate null and nonnull method signatures, also supports Kotlin
 
 ## 3.3.4
 - fix: follow redirect once (#115)

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>com.sangupta</groupId>
             <artifactId>murmur</artifactId>
             <version>1.0.0</version>

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import no.finn.unleash.event.EventDispatcher;
 import no.finn.unleash.event.ToggleEvaluated;
+import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.metric.UnleashMetricService;
 import no.finn.unleash.metric.UnleashMetricServiceImpl;
 import no.finn.unleash.repository.FeatureToggleRepository;
@@ -166,7 +167,7 @@ public final class DefaultUnleash implements Unleash {
         metricService.count(toggleName, enabled);
     }
 
-    private Map<String, Strategy> buildStrategyMap(Strategy[] strategies) {
+    private Map<String, Strategy> buildStrategyMap(@Nullable Strategy[] strategies) {
         Map<String, Strategy> map = new HashMap<>();
 
         BUILTIN_STRATEGIES.forEach(strategy -> map.put(strategy.getName(), strategy));

--- a/src/main/java/no/finn/unleash/FeatureToggle.java
+++ b/src/main/java/no/finn/unleash/FeatureToggle.java
@@ -4,13 +4,15 @@ import static java.util.Collections.emptyList;
 
 import java.util.Collections;
 import java.util.List;
+
+import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.variant.VariantDefinition;
 
 public final class FeatureToggle {
     private final String name;
     private final boolean enabled;
     private final List<ActivationStrategy> strategies;
-    private final List<VariantDefinition> variants;
+    @Nullable private final List<VariantDefinition> variants;
 
     public FeatureToggle(String name, boolean enabled, List<ActivationStrategy> strategies) {
         this(name, enabled, strategies, emptyList());
@@ -20,7 +22,7 @@ public final class FeatureToggle {
             String name,
             boolean enabled,
             List<ActivationStrategy> strategies,
-            List<VariantDefinition> variants) {
+            @Nullable List<VariantDefinition> variants) {
         this.name = name;
         this.enabled = enabled;
         this.strategies = strategies;

--- a/src/main/java/no/finn/unleash/UnleashContext.java
+++ b/src/main/java/no/finn/unleash/UnleashContext.java
@@ -3,6 +3,8 @@ package no.finn.unleash;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.util.UnleashConfig;
 
 public class UnleashContext {
@@ -20,11 +22,11 @@ public class UnleashContext {
     }
 
     public UnleashContext(
-            String appName,
-            String environment,
-            String userId,
-            String sessionId,
-            String remoteAddress,
+            @Nullable String appName,
+            @Nullable String environment,
+            @Nullable String userId,
+            @Nullable String sessionId,
+            @Nullable String remoteAddress,
             Map<String, String> properties) {
         this.appName = Optional.ofNullable(appName);
         this.environment = Optional.ofNullable(environment);
@@ -91,11 +93,11 @@ public class UnleashContext {
     }
 
     public static class Builder {
-        private String appName;
-        private String environment;
-        private String userId;
-        private String sessionId;
-        private String remoteAddress;
+        @Nullable private String appName;
+        @Nullable private String environment;
+        @Nullable private String userId;
+        @Nullable private String sessionId;
+        @Nullable private String remoteAddress;
 
         private final Map<String, String> properties = new HashMap<>();
 

--- a/src/main/java/no/finn/unleash/UnleashException.java
+++ b/src/main/java/no/finn/unleash/UnleashException.java
@@ -2,10 +2,11 @@ package no.finn.unleash;
 
 import no.finn.unleash.event.UnleashEvent;
 import no.finn.unleash.event.UnleashSubscriber;
+import no.finn.unleash.lang.Nullable;
 
 public class UnleashException extends RuntimeException implements UnleashEvent {
 
-    public UnleashException(String message, Throwable cause) {
+    public UnleashException(String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 

--- a/src/main/java/no/finn/unleash/Variant.java
+++ b/src/main/java/no/finn/unleash/Variant.java
@@ -2,22 +2,24 @@ package no.finn.unleash;
 
 import java.util.Objects;
 import java.util.Optional;
+
+import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.variant.Payload;
 
 public class Variant {
     public static final Variant DISABLED_VARIANT = new Variant("disabled", (String) null, false);
 
     private final String name;
-    private final Payload payload;
+    @Nullable private final Payload payload;
     private final boolean enabled;
 
-    public Variant(String name, Payload payload, boolean enabled) {
+    public Variant(String name, @Nullable  Payload payload, boolean enabled) {
         this.name = name;
         this.payload = payload;
         this.enabled = enabled;
     }
 
-    public Variant(String name, String payload, boolean enabled) {
+    public Variant(String name, @Nullable String payload, boolean enabled) {
         this.name = name;
         this.payload = new Payload("string", payload);
         this.enabled = enabled;

--- a/src/main/java/no/finn/unleash/event/package-info.java
+++ b/src/main/java/no/finn/unleash/event/package-info.java
@@ -1,0 +1,6 @@
+@NonNullApi
+@NonNullFields
+package no.finn.unleash.event;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;

--- a/src/main/java/no/finn/unleash/lang/NonNullApi.java
+++ b/src/main/java/no/finn/unleash/lang/NonNullApi.java
@@ -1,0 +1,14 @@
+package no.finn.unleash.lang;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Nonnull
+@TypeQualifierDefault({ElementType.PARAMETER, ElementType.METHOD})
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+public @interface NonNullApi {
+}
+

--- a/src/main/java/no/finn/unleash/lang/NonNullFields.java
+++ b/src/main/java/no/finn/unleash/lang/NonNullFields.java
@@ -1,0 +1,14 @@
+package no.finn.unleash.lang;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierDefault;
+import java.lang.annotation.*;
+
+
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Nonnull
+@TypeQualifierDefault(ElementType.FIELD)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+public @interface NonNullFields {
+}

--- a/src/main/java/no/finn/unleash/lang/Nullable.java
+++ b/src/main/java/no/finn/unleash/lang/Nullable.java
@@ -1,0 +1,14 @@
+package no.finn.unleash.lang;
+
+import javax.annotation.Nonnull;
+import javax.annotation.meta.TypeQualifierNickname;
+import javax.annotation.meta.When;
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Nonnull(when = When.MAYBE)
+@TypeQualifierNickname
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
+public @interface Nullable {
+}

--- a/src/main/java/no/finn/unleash/metric/MetricsBucket.java
+++ b/src/main/java/no/finn/unleash/metric/MetricsBucket.java
@@ -1,5 +1,7 @@
 package no.finn.unleash.metric;
 
+import no.finn.unleash.lang.Nullable;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Map;
@@ -9,7 +11,7 @@ import java.util.concurrent.ConcurrentMap;
 class MetricsBucket {
     private final ConcurrentMap<String, ToggleCount> toggles;
     private final LocalDateTime start;
-    private volatile LocalDateTime stop;
+    @Nullable private volatile LocalDateTime stop;
 
     MetricsBucket() {
         this.start = LocalDateTime.now(ZoneId.of("UTC"));
@@ -40,7 +42,7 @@ class MetricsBucket {
         return start;
     }
 
-    public LocalDateTime getStop() {
+    public @Nullable LocalDateTime getStop() {
         return stop;
     }
 }

--- a/src/main/java/no/finn/unleash/metric/package-info.java
+++ b/src/main/java/no/finn/unleash/metric/package-info.java
@@ -1,0 +1,7 @@
+@NonNullApi
+@NonNullFields
+
+package no.finn.unleash.metric;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;

--- a/src/main/java/no/finn/unleash/package-info.java
+++ b/src/main/java/no/finn/unleash/package-info.java
@@ -1,0 +1,7 @@
+@NonNullApi
+@NonNullFields
+
+package no.finn.unleash;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;

--- a/src/main/java/no/finn/unleash/repository/FeatureToggleRepository.java
+++ b/src/main/java/no/finn/unleash/repository/FeatureToggleRepository.java
@@ -6,6 +6,7 @@ import no.finn.unleash.FeatureToggle;
 import no.finn.unleash.UnleashException;
 import no.finn.unleash.event.EventDispatcher;
 import no.finn.unleash.event.UnleashReady;
+import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.util.UnleashConfig;
 import no.finn.unleash.util.UnleashScheduledExecutor;
 
@@ -69,7 +70,7 @@ public final class FeatureToggleRepository implements ToggleRepository {
     }
 
     @Override
-    public FeatureToggle getToggle(String name) {
+    public @Nullable FeatureToggle getToggle(String name) {
         return toggleCollection.getToggle(name);
     }
 

--- a/src/main/java/no/finn/unleash/repository/FeatureToggleResponse.java
+++ b/src/main/java/no/finn/unleash/repository/FeatureToggleResponse.java
@@ -6,6 +6,7 @@ import no.finn.unleash.FeatureToggle;
 import no.finn.unleash.UnleashException;
 import no.finn.unleash.event.UnleashEvent;
 import no.finn.unleash.event.UnleashSubscriber;
+import no.finn.unleash.lang.Nullable;
 
 public final class FeatureToggleResponse implements UnleashEvent {
 
@@ -18,7 +19,7 @@ public final class FeatureToggleResponse implements UnleashEvent {
     private final Status status;
     private final int httpStatusCode;
     private final ToggleCollection toggleCollection;
-    private String location;
+    @Nullable private String location;
 
     public FeatureToggleResponse(Status status, ToggleCollection toggleCollection) {
         this.status = status;
@@ -33,7 +34,7 @@ public final class FeatureToggleResponse implements UnleashEvent {
         this.toggleCollection = new ToggleCollection(emptyList);
     }
 
-    public FeatureToggleResponse(Status status, int httpStatusCode, String location) {
+    public FeatureToggleResponse(Status status, int httpStatusCode, @Nullable String location) {
         this(status, httpStatusCode);
         this.location = location;
     }
@@ -50,7 +51,7 @@ public final class FeatureToggleResponse implements UnleashEvent {
         return httpStatusCode;
     }
 
-    public String getLocation() {
+    public @Nullable String getLocation() {
         return location;
     }
 

--- a/src/main/java/no/finn/unleash/repository/JsonToggleCollectionDeserializer.java
+++ b/src/main/java/no/finn/unleash/repository/JsonToggleCollectionDeserializer.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Type;
 import java.util.*;
 import no.finn.unleash.ActivationStrategy;
 import no.finn.unleash.FeatureToggle;
+import no.finn.unleash.lang.Nullable;
 
 public class JsonToggleCollectionDeserializer implements JsonDeserializer<ToggleCollection> {
     private static final Type PARAMS_TYPE = new TypeToken<Map<String, String>>() {}.getType();
@@ -16,7 +17,7 @@ public class JsonToggleCollectionDeserializer implements JsonDeserializer<Toggle
             new TypeToken<Collection<FeatureToggle>>() {}.getType();
 
     @Override
-    public ToggleCollection deserialize(
+    public @Nullable ToggleCollection deserialize(
             JsonElement rootElement, Type type, JsonDeserializationContext context)
             throws JsonParseException {
 
@@ -31,7 +32,8 @@ public class JsonToggleCollectionDeserializer implements JsonDeserializer<Toggle
         }
     }
 
-    static ToggleCollection deserializeVersion0(
+    static @Nullable
+    ToggleCollection deserializeVersion0(
             JsonElement rootElement, JsonDeserializationContext context) {
         if (!rootElement.getAsJsonObject().has("features")) {
             return null;
@@ -60,7 +62,7 @@ public class JsonToggleCollectionDeserializer implements JsonDeserializer<Toggle
         return new ToggleCollection(featureToggles);
     }
 
-    static ToggleCollection deserializeVersion1(
+    static @Nullable ToggleCollection deserializeVersion1(
             JsonElement rootElement, JsonDeserializationContext context) {
         if (!rootElement.getAsJsonObject().has("features")) {
             return null;

--- a/src/main/java/no/finn/unleash/repository/JsonToggleParser.java
+++ b/src/main/java/no/finn/unleash/repository/JsonToggleParser.java
@@ -20,7 +20,7 @@ final class JsonToggleParser {
                                 ToggleCollection.class, new JsonToggleCollectionDeserializer())
                         .create();
         ToggleCollection gsonCollection = gson.fromJson(reader, ToggleCollection.class);
-        if (gsonCollection == null || gsonCollection.getFeatures() == null) {
+        if (gsonCollection == null) {
             throw new IllegalStateException("Could not extract toggles from json");
         }
         return new ToggleCollection(gsonCollection.getFeatures());

--- a/src/main/java/no/finn/unleash/repository/ToggleCollection.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleCollection.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import no.finn.unleash.FeatureToggle;
+import no.finn.unleash.lang.Nullable;
 
 public final class ToggleCollection {
     private final Collection<FeatureToggle> features;
@@ -19,7 +20,7 @@ public final class ToggleCollection {
         }
     }
 
-    private Collection<FeatureToggle> ensureNotNull(Collection<FeatureToggle> features) {
+    private Collection<FeatureToggle> ensureNotNull(@Nullable Collection<FeatureToggle> features) {
         if (features == null) {
             return Collections.emptyList();
         }

--- a/src/main/java/no/finn/unleash/repository/ToggleRepository.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleRepository.java
@@ -2,9 +2,10 @@ package no.finn.unleash.repository;
 
 import java.util.List;
 import no.finn.unleash.FeatureToggle;
+import no.finn.unleash.lang.Nullable;
 
 public interface ToggleRepository {
-    FeatureToggle getToggle(String name);
+    @Nullable FeatureToggle getToggle(String name);
 
     List<String> getFeatureNames();
 }

--- a/src/main/java/no/finn/unleash/repository/package-info.java
+++ b/src/main/java/no/finn/unleash/repository/package-info.java
@@ -1,0 +1,7 @@
+@NonNullApi
+@NonNullFields
+
+package no.finn.unleash.repository;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;

--- a/src/main/java/no/finn/unleash/strategy/ConstraintUtil.java
+++ b/src/main/java/no/finn/unleash/strategy/ConstraintUtil.java
@@ -5,10 +5,11 @@ import java.util.Optional;
 import no.finn.unleash.Constraint;
 import no.finn.unleash.Operator;
 import no.finn.unleash.UnleashContext;
+import no.finn.unleash.lang.Nullable;
 
 public class ConstraintUtil {
 
-    public static boolean validate(List<Constraint> constraints, UnleashContext context) {
+    public static boolean validate(@Nullable List<Constraint> constraints, UnleashContext context) {
         if (constraints != null && constraints.size() > 0) {
             return constraints.stream().allMatch(c -> validateConstraint(c, context));
         } else {

--- a/src/main/java/no/finn/unleash/strategy/StrategyUtils.java
+++ b/src/main/java/no/finn/unleash/strategy/StrategyUtils.java
@@ -1,6 +1,7 @@
 package no.finn.unleash.strategy;
 
 import com.sangupta.murmur.Murmur3;
+import no.finn.unleash.lang.Nullable;
 
 public final class StrategyUtils {
     private static final int ONE_HUNDRED = 100;
@@ -9,7 +10,7 @@ public final class StrategyUtils {
         return !isEmpty(cs);
     }
 
-    public static boolean isEmpty(final CharSequence cs) {
+    public static boolean isEmpty(@Nullable final CharSequence cs) {
         return cs == null || cs.length() == 0;
     }
 

--- a/src/main/java/no/finn/unleash/strategy/package-info.java
+++ b/src/main/java/no/finn/unleash/strategy/package-info.java
@@ -1,0 +1,7 @@
+@NonNullFields
+@NonNullApi
+
+package no.finn.unleash.strategy;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;

--- a/src/main/java/no/finn/unleash/util/IpAddressMatcher.java
+++ b/src/main/java/no/finn/unleash/util/IpAddressMatcher.java
@@ -15,6 +15,8 @@
  */
 package no.finn.unleash.util;
 
+import no.finn.unleash.lang.Nullable;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -31,7 +33,7 @@ import java.util.regex.Pattern;
 public final class IpAddressMatcher {
     private static final Pattern SPLITTER = Pattern.compile("/");
     private final int nMaskBits;
-    private final InetAddress requiredAddress;
+    @Nullable private final InetAddress requiredAddress;
 
     /**
      * Takes a specific IP address or a range specified using the IP/Netmask (e.g. 192.168.1.0/24 or
@@ -39,7 +41,7 @@ public final class IpAddressMatcher {
      *
      * @param ipAddress the address or range of addresses from which the request must come.
      */
-    public IpAddressMatcher(String ipAddress) {
+    public IpAddressMatcher(@Nullable String ipAddress) {
         final String trimmedIpAddress = ipAddress == null ? "" : ipAddress.trim();
 
         if (trimmedIpAddress.indexOf('/') > 0) {
@@ -52,14 +54,14 @@ public final class IpAddressMatcher {
         }
     }
 
-    public boolean matches(String address) {
+    public boolean matches(@Nullable String address) {
         if (address == null || address.isEmpty() || requiredAddress == null) {
             return false;
         }
 
         InetAddress remoteAddress = parseAddress(address);
 
-        if (!requiredAddress.getClass().equals(remoteAddress.getClass())) {
+        if (remoteAddress == null || !requiredAddress.getClass().equals(remoteAddress.getClass())) {
             return false;
         }
 
@@ -91,7 +93,7 @@ public final class IpAddressMatcher {
         return true;
     }
 
-    private InetAddress parseAddress(String address) {
+    private @Nullable InetAddress parseAddress(@Nullable String address) {
         if (address == null || address.isEmpty()) {
             return null;
         }

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -10,6 +10,7 @@ import no.finn.unleash.DefaultCustomHttpHeadersProviderImpl;
 import no.finn.unleash.UnleashContextProvider;
 import no.finn.unleash.event.NoOpSubscriber;
 import no.finn.unleash.event.UnleashSubscriber;
+import no.finn.unleash.lang.Nullable;
 
 public class UnleashConfig {
 
@@ -25,7 +26,7 @@ public class UnleashConfig {
     private final String instanceId;
     private final String sdkVersion;
     private final String backupFile;
-    private final String projectName;
+    @Nullable private final String projectName;
     private final long fetchTogglesInterval;
     private final long sendMetricsInterval;
     private final boolean disableMetrics;
@@ -36,23 +37,23 @@ public class UnleashConfig {
     private final UnleashSubscriber unleashSubscriber;
 
     private UnleashConfig(
-            URI unleashAPI,
+            @Nullable URI unleashAPI,
             Map<String, String> customHttpHeaders,
             CustomHttpHeadersProvider customHttpHeadersProvider,
-            String appName,
+            @Nullable String appName,
             String environment,
-            String instanceId,
+            @Nullable String instanceId,
             String sdkVersion,
             String backupFile,
-            String projectName,
+            @Nullable String projectName,
             long fetchTogglesInterval,
             long sendMetricsInterval,
             boolean disableMetrics,
             UnleashContextProvider contextProvider,
             boolean isProxyAuthenticationByJvmProperties,
             boolean synchronousFetchOnInitialisation,
-            UnleashScheduledExecutor unleashScheduledExecutor,
-            UnleashSubscriber unleashSubscriber) {
+            @Nullable UnleashScheduledExecutor unleashScheduledExecutor,
+            @Nullable UnleashSubscriber unleashSubscriber) {
 
         if (appName == null) {
             throw new IllegalStateException("You are required to specify the unleash appName");
@@ -144,7 +145,7 @@ public class UnleashConfig {
         return sdkVersion;
     }
 
-    public String getProjectName() {
+    public @Nullable String getProjectName() {
         return projectName;
     }
 
@@ -191,7 +192,7 @@ public class UnleashConfig {
     static class ProxyAuthenticator extends Authenticator {
 
         @Override
-        protected PasswordAuthentication getPasswordAuthentication() {
+        protected @Nullable PasswordAuthentication getPasswordAuthentication() {
             if (getRequestorType() == RequestorType.PROXY) {
                 final String proto = getRequestingProtocol().toLowerCase();
                 final String proxyHost = System.getProperty(proto + ".proxyHost", "");
@@ -212,24 +213,24 @@ public class UnleashConfig {
 
     public static class Builder {
 
-        private URI unleashAPI;
+        private @Nullable URI unleashAPI;
         private Map<String, String> customHttpHeaders = new HashMap<>();
         private CustomHttpHeadersProvider customHttpHeadersProvider =
                 new DefaultCustomHttpHeadersProviderImpl();
-        private String appName;
+        private @Nullable String appName;
         private String environment = "default";
         private String instanceId = getDefaultInstanceId();
         private String sdkVersion = getDefaultSdkVersion();
-        private String backupFile;
-        private String projectName;
+        private @Nullable String backupFile;
+        private @Nullable String projectName;
         private long fetchTogglesInterval = 10;
         private long sendMetricsInterval = 60;
         private boolean disableMetrics = false;
         private UnleashContextProvider contextProvider =
                 UnleashContextProvider.getDefaultProvider();
         private boolean synchronousFetchOnInitialisation = false;
-        private UnleashScheduledExecutor scheduledExecutor;
-        private UnleashSubscriber unleashSubscriber;
+        private @Nullable UnleashScheduledExecutor scheduledExecutor;
+        private @Nullable UnleashSubscriber unleashSubscriber;
         private boolean isProxyAuthenticationByJvmProperties;
 
         private static String getHostname() {

--- a/src/main/java/no/finn/unleash/util/UnleashScheduledExecutor.java
+++ b/src/main/java/no/finn/unleash/util/UnleashScheduledExecutor.java
@@ -1,10 +1,13 @@
 package no.finn.unleash.util;
 
+import no.finn.unleash.lang.Nullable;
+
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 
 public interface UnleashScheduledExecutor {
+    @Nullable
     ScheduledFuture setInterval(Runnable command, long initialDelaySec, long periodSec)
             throws RejectedExecutionException;
 

--- a/src/main/java/no/finn/unleash/util/UnleashScheduledExecutorImpl.java
+++ b/src/main/java/no/finn/unleash/util/UnleashScheduledExecutorImpl.java
@@ -1,6 +1,8 @@
 package no.finn.unleash.util;
 
 import java.util.concurrent.*;
+
+import no.finn.unleash.lang.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,6 +10,7 @@ public class UnleashScheduledExecutorImpl implements UnleashScheduledExecutor {
 
     private static final Logger LOG = LoggerFactory.getLogger(UnleashScheduledExecutorImpl.class);
 
+    @Nullable
     private static UnleashScheduledExecutorImpl INSTANCE;
 
     private final ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
@@ -36,7 +39,7 @@ public class UnleashScheduledExecutorImpl implements UnleashScheduledExecutor {
     }
 
     @Override
-    public ScheduledFuture setInterval(Runnable command, long initialDelaySec, long periodSec) {
+    public @Nullable ScheduledFuture setInterval(Runnable command, long initialDelaySec, long periodSec) {
         try {
             return scheduledThreadPoolExecutor.scheduleAtFixedRate(
                     command, initialDelaySec, periodSec, TimeUnit.SECONDS);

--- a/src/main/java/no/finn/unleash/util/package-info.java
+++ b/src/main/java/no/finn/unleash/util/package-info.java
@@ -1,0 +1,7 @@
+@NonNullApi
+@NonNullFields
+
+package no.finn.unleash.util;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;

--- a/src/main/java/no/finn/unleash/variant/Payload.java
+++ b/src/main/java/no/finn/unleash/variant/Payload.java
@@ -1,12 +1,14 @@
 package no.finn.unleash.variant;
 
+import no.finn.unleash.lang.Nullable;
+
 import java.util.Objects;
 
 public class Payload {
     private String type;
-    private String value;
+    @Nullable private String value;
 
-    public Payload(String type, String value) {
+    public Payload(String type,@Nullable String value) {
         this.type = type;
         this.value = value;
     }
@@ -15,12 +17,12 @@ public class Payload {
         return type;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Payload payload = (Payload) o;

--- a/src/main/java/no/finn/unleash/variant/VariantDefinition.java
+++ b/src/main/java/no/finn/unleash/variant/VariantDefinition.java
@@ -3,16 +3,17 @@ package no.finn.unleash.variant;
 import java.util.Collections;
 import java.util.List;
 import no.finn.unleash.Variant;
+import no.finn.unleash.lang.Nullable;
 
 public class VariantDefinition {
 
     private final String name;
     private final int weight;
-    private final Payload payload;
-    private final List<VariantOverride> overrides;
+    @Nullable private final Payload payload;
+    @Nullable private final List<VariantOverride> overrides;
 
     public VariantDefinition(
-            String name, int weight, Payload payload, List<VariantOverride> overrides) {
+        String name, int weight, @Nullable Payload payload, @Nullable List<VariantOverride> overrides) {
         this.name = name;
         this.weight = weight;
         this.payload = payload;
@@ -31,7 +32,7 @@ public class VariantDefinition {
         return weight;
     }
 
-    public Payload getPayload() {
+    public @Nullable Payload getPayload() {
         return payload;
     }
 

--- a/src/main/java/no/finn/unleash/variant/VariantUtil.java
+++ b/src/main/java/no/finn/unleash/variant/VariantUtil.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import no.finn.unleash.FeatureToggle;
 import no.finn.unleash.UnleashContext;
 import no.finn.unleash.Variant;
+import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.strategy.StrategyUtils;
 
 public final class VariantUtil {
@@ -61,7 +62,10 @@ public final class VariantUtil {
     }
 
     public static Variant selectVariant(
-            FeatureToggle featureToggle, UnleashContext context, Variant defaultVariant) {
+        @Nullable FeatureToggle featureToggle, UnleashContext context, Variant defaultVariant) {
+        if(featureToggle == null) {
+            return defaultVariant;
+        }
         List<VariantDefinition> variants = featureToggle.getVariants();
         int totalWeight = variants.stream().mapToInt(VariantDefinition::getWeight).sum();
         if (totalWeight == 0) {

--- a/src/main/java/no/finn/unleash/variant/package-info.java
+++ b/src/main/java/no/finn/unleash/variant/package-info.java
@@ -1,0 +1,7 @@
+@NonNullFields
+@NonNullApi
+
+package no.finn.unleash.variant;
+
+import no.finn.unleash.lang.NonNullApi;
+import no.finn.unleash.lang.NonNullFields;


### PR DESCRIPTION
In support for #114 

To avoid adding `@Nonnull` annotations everywhere, this PR adds `package-info.java` files and essentially marks the entire package as `@Nonnull` for return types, parameters, and fields. The remaining changes then only have to call out where nullability is allowed by adding the `@Nullable` annotation.