### PR TITLE
fix: Add logging for when a matching strategy is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fix: BREAKING CHANGE UnleashConfig constructor is now private.
   Use UnleashConfig.Builder to get instance of UnleashConfig
 - feat: Add annotations to indicate null and nonnull method signatures, also supports Kotlin
+- feat: Add warning when a matching strategy for a toggle can't be found
 
 ## 3.3.4
 - fix: follow redirect once (#115)

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -21,8 +21,11 @@ import no.finn.unleash.repository.ToggleBackupHandlerFile;
 import no.finn.unleash.repository.ToggleRepository;
 import no.finn.unleash.strategy.*;
 import no.finn.unleash.util.UnleashConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class DefaultUnleash implements Unleash {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultUnleash.class);
     private static final List<Strategy> BUILTIN_STRATEGIES =
             Arrays.asList(
                     new DefaultStrategy(),
@@ -120,12 +123,20 @@ public final class DefaultUnleash implements Unleash {
             enabled =
                     featureToggle.getStrategies().stream()
                             .anyMatch(
-                                    as ->
-                                            getStrategy(as.getName())
-                                                    .isEnabled(
-                                                            as.getParameters(),
-                                                            enhancedContext,
-                                                            as.getConstraints()));
+                                    strategy -> {
+                                        Strategy configuredStrategy = getStrategy(strategy.getName());
+                                        if (configuredStrategy == UNKNOWN_STRATEGY) {
+                                            LOGGER.warn(
+                                                    "Unable to find matching strategy for toggle:{} strategy:{}",
+                                                    toggleName,
+                                                    strategy.getName());
+                                        }
+
+                                        return configuredStrategy.isEnabled(
+                                                strategy.getParameters(),
+                                                enhancedContext,
+                                                strategy.getConstraints());
+                                    });
         }
         return enabled;
     }


### PR DESCRIPTION
I created a new custom activation in Unleash and was very confused as to why it wasn't taking place. People familiar with Unleash would have know what was wrong, in that I hadn't created/registered a corresponding strategy.

This PR adds a warning so it is clear in the calling app which toggle/strategy is affected and how they can address it.
