### PR TITLE
feat: Add support for fallback strategy

### DIFF
--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -219,7 +219,8 @@ public final class DefaultUnleash implements Unleash {
     }
 
     private Strategy getStrategy(String strategy) {
-        return strategyMap.containsKey(strategy) ? strategyMap.get(strategy) : UNKNOWN_STRATEGY;
+        Strategy foundStrategy = strategyMap.getOrDefault(strategy, config.getFallbackStrategy());
+        return foundStrategy != null ? foundStrategy : UNKNOWN_STRATEGY;
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -38,7 +38,7 @@ public final class DefaultUnleash implements Unleash {
                     new UserWithIdStrategy(),
                     new FlexibleRolloutStrategy());
 
-    private static final UnknownStrategy UNKNOWN_STRATEGY = new UnknownStrategy();
+    public static final UnknownStrategy UNKNOWN_STRATEGY = new UnknownStrategy();
 
     private final UnleashMetricService metricService;
     private final ToggleRepository toggleRepository;
@@ -219,8 +219,7 @@ public final class DefaultUnleash implements Unleash {
     }
 
     private Strategy getStrategy(String strategy) {
-        Strategy foundStrategy = strategyMap.getOrDefault(strategy, config.getFallbackStrategy());
-        return foundStrategy != null ? foundStrategy : UNKNOWN_STRATEGY;
+        return strategyMap.getOrDefault(strategy, config.getFallbackStrategy());
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -13,6 +13,8 @@ import no.finn.unleash.event.UnleashSubscriber;
 import no.finn.unleash.lang.Nullable;
 import no.finn.unleash.strategy.Strategy;
 
+import static no.finn.unleash.DefaultUnleash.UNKNOWN_STRATEGY;
+
 public class UnleashConfig {
 
     static final String UNLEASH_APP_NAME_HEADER = "UNLEASH-APPNAME";
@@ -57,7 +59,6 @@ public class UnleashConfig {
             @Nullable UnleashScheduledExecutor unleashScheduledExecutor,
             @Nullable UnleashSubscriber unleashSubscriber,
             @Nullable Strategy fallbackStrategy) {
-        this.fallbackStrategy = fallbackStrategy;
 
         if (appName == null) {
             throw new IllegalStateException("You are required to specify the unleash appName");
@@ -77,6 +78,12 @@ public class UnleashConfig {
 
         if (unleashSubscriber == null) {
             throw new IllegalStateException("You are required to specify a subscriber");
+        }
+
+        if ( fallbackStrategy == null) {
+            this.fallbackStrategy = UNKNOWN_STRATEGY;
+        } else {
+            this.fallbackStrategy = fallbackStrategy;
         }
 
         if (isProxyAuthenticationByJvmProperties) {

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -11,6 +11,7 @@ import no.finn.unleash.UnleashContextProvider;
 import no.finn.unleash.event.NoOpSubscriber;
 import no.finn.unleash.event.UnleashSubscriber;
 import no.finn.unleash.lang.Nullable;
+import no.finn.unleash.strategy.Strategy;
 
 public class UnleashConfig {
 
@@ -35,6 +36,7 @@ public class UnleashConfig {
     private final boolean synchronousFetchOnInitialisation;
     private final UnleashScheduledExecutor unleashScheduledExecutor;
     private final UnleashSubscriber unleashSubscriber;
+    @Nullable private final Strategy fallbackStrategy;
 
     private UnleashConfig(
             @Nullable URI unleashAPI,
@@ -53,7 +55,9 @@ public class UnleashConfig {
             boolean isProxyAuthenticationByJvmProperties,
             boolean synchronousFetchOnInitialisation,
             @Nullable UnleashScheduledExecutor unleashScheduledExecutor,
-            @Nullable UnleashSubscriber unleashSubscriber) {
+            @Nullable UnleashSubscriber unleashSubscriber,
+            @Nullable Strategy fallbackStrategy) {
+        this.fallbackStrategy = fallbackStrategy;
 
         if (appName == null) {
             throw new IllegalStateException("You are required to specify the unleash appName");
@@ -189,6 +193,11 @@ public class UnleashConfig {
         return isProxyAuthenticationByJvmProperties;
     }
 
+    @Nullable
+    public Strategy getFallbackStrategy() {
+        return fallbackStrategy;
+    }
+
     static class ProxyAuthenticator extends Authenticator {
 
         @Override
@@ -232,6 +241,7 @@ public class UnleashConfig {
         private @Nullable UnleashScheduledExecutor scheduledExecutor;
         private @Nullable UnleashSubscriber unleashSubscriber;
         private boolean isProxyAuthenticationByJvmProperties;
+        private Strategy fallbackStrategy;
 
         private static String getHostname() {
             String hostName = System.getProperty("hostname");
@@ -333,6 +343,11 @@ public class UnleashConfig {
             return this;
         }
 
+        public Builder fallbackStrategy(@Nullable Strategy fallbackStrategy) {
+            this.fallbackStrategy = fallbackStrategy;
+            return this;
+        }
+
         private String getBackupFile() {
             if (backupFile != null) {
                 return backupFile;
@@ -361,7 +376,8 @@ public class UnleashConfig {
                     synchronousFetchOnInitialisation,
                     Optional.ofNullable(scheduledExecutor)
                             .orElseGet(UnleashScheduledExecutorImpl::getInstance),
-                    Optional.ofNullable(unleashSubscriber).orElseGet(NoOpSubscriber::new));
+                    Optional.ofNullable(unleashSubscriber).orElseGet(NoOpSubscriber::new),
+                    fallbackStrategy);
         }
 
         public String getDefaultSdkVersion() {


### PR DESCRIPTION
That allows registering a fallback strategy which will support a broader idea of a 'context matching strategy'. I'll create a separate PR for that strategy to keep the PRs focused on each change.