### PR TITLE
Add support for leveraging namePrefix in Java SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.2.1
 - fix: Make sure empty bootstrap path does not crash app
 - feat: Default to trying UNLEASH_BOOTSTRAP_FILE environment variable for finding bootstrap
+- feat: Add support for filtering by namePrefix
 
 ## 4.2.0
 - feat: Add ability to bootstrap features from files via UNLEASH_BOOTSTRAP_FILE (#129)

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -126,6 +126,7 @@ public final class DefaultUnleash implements Unleash {
             String toggleName,
             UnleashContext context,
             BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+        checkIfToggleMatchesNamePrefix(toggleName);
         FeatureToggle featureToggle = toggleRepository.getToggle(toggleName);
         boolean enabled;
         UnleashContext enhancedContext = context.applyStaticFields(config);
@@ -157,6 +158,17 @@ public final class DefaultUnleash implements Unleash {
                                     });
         }
         return enabled;
+    }
+
+    private void checkIfToggleMatchesNamePrefix(String toggleName) {
+        if (config.getNamePrefix() != null) {
+            if (!toggleName.startsWith(config.getNamePrefix())) {
+                LOGGER.warn(
+                        "Toggle [{}] doesnt start with configured name prefix of {} so it will always be disabled",
+                        toggleName,
+                        config.getNamePrefix());
+            }
+        }
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/DefaultUnleash.java
+++ b/src/main/java/no/finn/unleash/DefaultUnleash.java
@@ -164,7 +164,7 @@ public final class DefaultUnleash implements Unleash {
         if (config.getNamePrefix() != null) {
             if (!toggleName.startsWith(config.getNamePrefix())) {
                 LOGGER.warn(
-                        "Toggle [{}] doesnt start with configured name prefix of {} so it will always be disabled",
+                        "Toggle [{}] doesnt start with configured name prefix of [{}] so it will always be disabled",
                         toggleName,
                         config.getNamePrefix());
             }

--- a/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
+++ b/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
@@ -20,7 +20,7 @@ public final class HttpToggleFetcher implements ToggleFetcher {
     private Optional<String> etag = Optional.empty();
 
     private final URL toggleUrl;
-    private UnleashConfig unleashConfig;
+    private final UnleashConfig unleashConfig;
 
     public HttpToggleFetcher(UnleashConfig unleashConfig) {
         this.unleashConfig = unleashConfig;
@@ -29,6 +29,11 @@ public final class HttpToggleFetcher implements ToggleFetcher {
                     unleashConfig
                             .getUnleashURLs()
                             .getFetchTogglesURL(unleashConfig.getProjectName());
+        } else if (unleashConfig.getNamePrefix() != null) {
+            this.toggleUrl =
+                    unleashConfig
+                            .getUnleashURLs()
+                            .getFetchTogglesURLWithNamePrefix(unleashConfig.getNamePrefix());
         } else {
             this.toggleUrl = unleashConfig.getUnleashURLs().getFetchTogglesURL();
         }

--- a/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
+++ b/src/main/java/no/finn/unleash/repository/HttpToggleFetcher.java
@@ -24,19 +24,9 @@ public final class HttpToggleFetcher implements ToggleFetcher {
 
     public HttpToggleFetcher(UnleashConfig unleashConfig) {
         this.unleashConfig = unleashConfig;
-        if (unleashConfig.getProjectName() != null) {
-            this.toggleUrl =
-                    unleashConfig
-                            .getUnleashURLs()
-                            .getFetchTogglesURL(unleashConfig.getProjectName());
-        } else if (unleashConfig.getNamePrefix() != null) {
-            this.toggleUrl =
-                    unleashConfig
-                            .getUnleashURLs()
-                            .getFetchTogglesURLWithNamePrefix(unleashConfig.getNamePrefix());
-        } else {
-            this.toggleUrl = unleashConfig.getUnleashURLs().getFetchTogglesURL();
-        }
+        this.toggleUrl = unleashConfig
+            .getUnleashURLs()
+            .getFetchTogglesURL(unleashConfig.getProjectName(), unleashConfig.getNamePrefix());
     }
 
     @Override

--- a/src/main/java/no/finn/unleash/repository/ToggleBootstrapHandler.java
+++ b/src/main/java/no/finn/unleash/repository/ToggleBootstrapHandler.java
@@ -43,7 +43,7 @@ public class ToggleBootstrapHandler {
         return new ToggleCollection(Collections.emptyList());
     }
 
-    private static class ToggleBootstrapRead implements UnleashEvent {
+    public static class ToggleBootstrapRead implements UnleashEvent {
         private final ToggleCollection toggleCollection;
 
         private ToggleBootstrapRead(ToggleCollection toggleCollection) {

--- a/src/main/java/no/finn/unleash/util/UnleashConfig.java
+++ b/src/main/java/no/finn/unleash/util/UnleashConfig.java
@@ -31,6 +31,7 @@ public class UnleashConfig {
     private final String sdkVersion;
     private final String backupFile;
     @Nullable private final String projectName;
+    @Nullable private final String namePrefix;
     private final long fetchTogglesInterval;
     private final long sendMetricsInterval;
     private final boolean disableMetrics;
@@ -52,6 +53,7 @@ public class UnleashConfig {
             String sdkVersion,
             String backupFile,
             @Nullable String projectName,
+            @Nullable String namePrefix,
             long fetchTogglesInterval,
             long sendMetricsInterval,
             boolean disableMetrics,
@@ -103,6 +105,7 @@ public class UnleashConfig {
         this.sdkVersion = sdkVersion;
         this.backupFile = backupFile;
         this.projectName = projectName;
+        this.namePrefix = namePrefix;
         this.fetchTogglesInterval = fetchTogglesInterval;
         this.sendMetricsInterval = sendMetricsInterval;
         this.disableMetrics = disableMetrics;
@@ -214,6 +217,11 @@ public class UnleashConfig {
         return toggleBootstrapProvider;
     }
 
+    @Nullable
+    public String getNamePrefix() {
+        return namePrefix;
+    }
+
     static class ProxyAuthenticator extends Authenticator {
 
         @Override
@@ -245,9 +253,10 @@ public class UnleashConfig {
         private @Nullable String appName;
         private String environment = "default";
         private String instanceId = getDefaultInstanceId();
-        private String sdkVersion = getDefaultSdkVersion();
+        private final String sdkVersion = getDefaultSdkVersion();
         private @Nullable String backupFile;
         private @Nullable String projectName;
+        private @Nullable String namePrefix;
         private long fetchTogglesInterval = 10;
         private long sendMetricsInterval = 60;
         private boolean disableMetrics = false;
@@ -257,7 +266,7 @@ public class UnleashConfig {
         private @Nullable UnleashScheduledExecutor scheduledExecutor;
         private @Nullable UnleashSubscriber unleashSubscriber;
         private boolean isProxyAuthenticationByJvmProperties;
-        private Strategy fallbackStrategy;
+        private @Nullable Strategy fallbackStrategy;
         private @Nullable ToggleBootstrapProvider toggleBootstrapProvider;
 
         private static String getHostname() {
@@ -312,6 +321,11 @@ public class UnleashConfig {
 
         public Builder projectName(String projectName) {
             this.projectName = projectName;
+            return this;
+        }
+
+        public Builder namePrefix(String namePrefix) {
+            this.namePrefix = namePrefix;
             return this;
         }
 
@@ -391,6 +405,7 @@ public class UnleashConfig {
                     sdkVersion,
                     getBackupFile(),
                     projectName,
+                    namePrefix,
                     fetchTogglesInterval,
                     sendMetricsInterval,
                     disableMetrics,

--- a/src/main/java/no/finn/unleash/util/UnleashURLs.java
+++ b/src/main/java/no/finn/unleash/util/UnleashURLs.java
@@ -1,7 +1,10 @@
 package no.finn.unleash.util;
 
+import no.finn.unleash.lang.Nullable;
+
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 public class UnleashURLs {
@@ -25,15 +28,6 @@ public class UnleashURLs {
         return fetchTogglesURL;
     }
 
-    public URL getFetchTogglesURL(String projectName) {
-        try {
-            return URI.create(fetchTogglesURL + "?project=" + projectName).normalize().toURL();
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Project name [" + projectName + "] was not URL friendly.", e);
-        }
-    }
-
     public URL getClientMetricsURL() {
         return clientMetricsURL;
     }
@@ -42,12 +36,27 @@ public class UnleashURLs {
         return clientRegisterURL;
     }
 
-    public URL getFetchTogglesURLWithNamePrefix(String namePrefix) {
+    public URL getFetchTogglesURL(@Nullable String projectName, @Nullable String namePrefix) {
+        StringBuilder suffix = new StringBuilder("");
+        appendParam(suffix, "project", projectName);
+        appendParam(suffix, "namePrefix", namePrefix);
+
         try {
-            return URI.create(fetchTogglesURL + "?namePrefix=" + namePrefix).normalize().toURL();
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "namePrefix [" + namePrefix + "] was not URL friendly.", e);
+            return URI.create(fetchTogglesURL + suffix.toString()).normalize().toURL();
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("fetchTogglesURL [" + fetchTogglesURL + suffix + "] was not URL friendly.", e);
         }
     }
+
+    private void appendParam(StringBuilder suffix, String key, @Nullable String value) {
+        if(value == null) return;
+        if(suffix.length() == 0){
+            suffix.append("?");
+        } else {
+            suffix.append("&");
+        }
+        suffix.append(key).append("=").append(value);
+    }
+
+
 }

--- a/src/main/java/no/finn/unleash/util/UnleashURLs.java
+++ b/src/main/java/no/finn/unleash/util/UnleashURLs.java
@@ -43,7 +43,7 @@ public class UnleashURLs {
 
         try {
             return URI.create(fetchTogglesURL + suffix.toString()).normalize().toURL();
-        } catch (MalformedURLException e) {
+        } catch (IllegalArgumentException|MalformedURLException e) {
             throw new IllegalArgumentException("fetchTogglesURL [" + fetchTogglesURL + suffix + "] was not URL friendly.", e);
         }
     }

--- a/src/main/java/no/finn/unleash/util/UnleashURLs.java
+++ b/src/main/java/no/finn/unleash/util/UnleashURLs.java
@@ -27,9 +27,7 @@ public class UnleashURLs {
 
     public URL getFetchTogglesURL(String projectName) {
         try {
-            return URI.create(fetchTogglesURL.toString() + "?project=" + projectName)
-                    .normalize()
-                    .toURL();
+            return URI.create(fetchTogglesURL + "?project=" + projectName).normalize().toURL();
         } catch (Exception e) {
             throw new IllegalArgumentException(
                     "Project name [" + projectName + "] was not URL friendly.", e);
@@ -42,5 +40,14 @@ public class UnleashURLs {
 
     public URL getClientRegisterURL() {
         return clientRegisterURL;
+    }
+
+    public URL getFetchTogglesURLWithNamePrefix(String namePrefix) {
+        try {
+            return URI.create(fetchTogglesURL + "?namePrefix=" + namePrefix).normalize().toURL();
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "namePrefix [" + namePrefix + "] was not URL friendly.", e);
+        }
     }
 }

--- a/src/test/java/no/finn/unleash/event/SubscriberTest.java
+++ b/src/test/java/no/finn/unleash/event/SubscriberTest.java
@@ -16,7 +16,11 @@ import no.finn.unleash.DefaultUnleash;
 import no.finn.unleash.SynchronousTestExecutor;
 import no.finn.unleash.Unleash;
 import no.finn.unleash.UnleashException;
+import no.finn.unleash.metric.ClientMetrics;
+import no.finn.unleash.metric.ClientRegistration;
 import no.finn.unleash.repository.FeatureToggleResponse;
+import no.finn.unleash.repository.HttpToggleFetcher;
+import no.finn.unleash.repository.ToggleBootstrapHandler;
 import no.finn.unleash.util.UnleashConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,15 +65,14 @@ public class SubscriberTest {
         assertThat(testSubscriber.toggleEnabled).isFalse();
         assertThat(testSubscriber.errors).hasSize(2);
 
-        assertThat(testSubscriber.events)
-                .hasSize(
-                        1 // Bootstrapping
-                                + 3 // feature evaluations
-                                + 2 // toggle fetches
-                                + 1 // unleash ready
-                                + 1 // client registration
-                                + 1 // client metrics
-                        );
+//        assertThat(testSubscriber.events).filteredOn(e -> e instanceof ToggleBootstrapHandler.ToggleBootstrapRead).hasSize(1);
+        assertThat(testSubscriber.events).filteredOn(e -> e instanceof UnleashReady).hasSize(1);
+        assertThat(testSubscriber.events).filteredOn(e -> e instanceof ToggleEvaluated).hasSize(3);
+        assertThat(testSubscriber.events).filteredOn(e -> e instanceof FeatureToggleResponse).hasSize(2);
+        assertThat(testSubscriber.events).filteredOn(e -> e instanceof ClientRegistration).hasSize(1);
+        assertThat(testSubscriber.events).filteredOn(e -> e instanceof ClientMetrics).hasSize(1);
+        assertThat(testSubscriber.events).hasSize(8);
+
     }
 
     private class TestSubscriber implements UnleashSubscriber {

--- a/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
+++ b/src/test/java/no/finn/unleash/repository/HttpToggleFetcherTest.java
@@ -346,6 +346,6 @@ public class HttpToggleFetcherTest {
                 UnleashConfig.builder().appName("test").unleashAPI(uri).projectName(name).build();
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> new HttpToggleFetcher(config))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Project name [" + name + "] was not URL friendly.");
+                .hasMessageContaining("?project="+name+"] was not URL friendly.");
     }
 }

--- a/src/test/java/no/finn/unleash/util/UnleashURLsTest.java
+++ b/src/test/java/no/finn/unleash/util/UnleashURLsTest.java
@@ -36,6 +36,35 @@ public class UnleashURLsTest {
                 .isEqualTo("http://unleash.com/api/client/features");
     }
 
+    @Test
+    public void should_set_build_fetch_url_if_project_and_prefix_are_null() {
+        UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
+        assertThat(urls.getFetchTogglesURL(null, null).toString())
+            .isEqualTo("http://unleash.com/api/client/features");
+    }
+
+    @Test
+    public void should_set_build_fetch_url_with_project() {
+        UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
+        assertThat(urls.getFetchTogglesURL("myProject", null).toString())
+            .isEqualTo("http://unleash.com/api/client/features?project=myProject");
+    }
+
+    @Test
+    public void should_set_build_fetch_url_with_nameprefix() {
+        UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
+        assertThat(urls.getFetchTogglesURL(null, "prefix.").toString())
+            .isEqualTo("http://unleash.com/api/client/features?namePrefix=prefix.");
+    }
+
+
+    @Test
+    public void should_set_build_fetch_url_with_project_and_nameprefix() {
+        UnleashURLs urls = new UnleashURLs(URI.create("http://unleash.com/api/"));
+        assertThat(urls.getFetchTogglesURL("aproject", "prefix.").toString())
+            .isEqualTo("http://unleash.com/api/client/features?project=aproject&namePrefix=prefix.");
+    }
+
     @Test()
     public void should_throw() {
         assertThrows(


### PR DESCRIPTION
Also warn if trying to check for toggles that don't match the prefix to avoid confusion for why it is always disabled.