### PR TITLE
Upgrades log4j2 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 
     <properties>
         <version.slf4j>1.7.32</version.slf4j>
-        <version.log4j2>2.15.0</version.log4j2>
-        <version.junit5>5.8.1</version.junit5>
+        <version.log4j2>2.16.0</version.log4j2>
+        <version.junit5>5.8.2</version.junit5>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.unleash.specification>4.0.0</version.unleash.specification>
         <arguments />
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.8</version>
+            <version>2.8.9</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- Though we don't distribute log4j on runtime/compile classpath, since
  we have it as a test dependency, it's good to clear up confusion and
  make sure to use a presumably bugfree version for our test code as
  well