### PR TITLE
fix: make bootstrap not fail when passed invalid json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-
+## 5.0.4
+- fix: Bootstrap no longer fails hard when passed invalid json. It now returns an empty list of features if the bootstrap json could not be parsed.
 ## 5.0.0
 - chore: Refactor package names. Moving from `no.finn.unleash` to `io.getunleash` to reflect where development is taking place.
 

--- a/src/main/java/io/getunleash/repository/ToggleBootstrapHandler.java
+++ b/src/main/java/io/getunleash/repository/ToggleBootstrapHandler.java
@@ -1,5 +1,6 @@
 package io.getunleash.repository;
 
+import com.google.gson.JsonSyntaxException;
 import io.getunleash.UnleashException;
 import io.getunleash.event.EventDispatcher;
 import io.getunleash.event.UnleashEvent;
@@ -28,7 +29,7 @@ public class ToggleBootstrapHandler {
                 ToggleCollection toggleCollection = JsonToggleParser.fromJson(stringReader);
                 eventDispatcher.dispatch(new ToggleBootstrapRead(toggleCollection));
                 return toggleCollection;
-            } catch (IllegalStateException ise) {
+            } catch (IllegalStateException | JsonSyntaxException ise) {
                 eventDispatcher.dispatch(
                         new UnleashException("Failed to read toggle bootstrap", ise));
             }

--- a/src/test/java/io/getunleash/repository/ToggleBootstrapHandlerTest.java
+++ b/src/test/java/io/getunleash/repository/ToggleBootstrapHandlerTest.java
@@ -43,6 +43,18 @@ public class ToggleBootstrapHandlerTest {
     }
 
     @Test
+    public void returns_empty_collection_if_invalid_json_string() {
+        UnleashConfig config =
+            UnleashConfig.builder()
+                .appName("test")
+                .unleashAPI("http://http://unleash.org")
+                .build();
+        ToggleBootstrapHandler handler = new ToggleBootstrapHandler(config);
+        ToggleCollection parse = handler.parse("qw;lkeruiqwplkerjql;kjglksjdfglksdjflkwsdj");
+        assertThat(parse.getFeatures()).isEmpty();
+    }
+
+    @Test
     public void handles_provider_returning_null() {
         UnleashConfig config =
                 UnleashConfig.builder()


### PR DESCRIPTION
Co-authored-by: Simon Hornby <simon@getunleash.ai>