### PR TITLE
fix: upgrade jackson databind due to vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,19 +116,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
I was setting up unleash Java SDK on my local machine and discovered that jackson databind is outdated and has vulnerability in version 2.13.1.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518

Also updated jackson-core and jackson-annotations to match.

Tests ran good and looks stable.