### PR TITLE
Add getFeatureToggleDefinition to interface

### DIFF
--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -190,6 +190,12 @@ public class DefaultUnleash implements Unleash {
         return getVariant(toggleName, contextProvider.getContext(), defaultValue);
     }
 
+    /**
+     * Use more().getFeatureToggleDefinition() instead
+     *
+     * @return the feature toggle
+     */
+    @Deprecated
     public Optional<FeatureToggle> getFeatureToggleDefinition(String toggleName) {
         return ofNullable(featureRepository.getToggle(toggleName));
     }
@@ -243,6 +249,11 @@ public class DefaultUnleash implements Unleash {
         @Override
         public List<String> getFeatureToggleNames() {
             return featureRepository.getFeatureNames();
+        }
+
+        @Override
+        public Optional<FeatureToggle> getFeatureToggleDefinition(String toggleName) {
+            return ofNullable(featureRepository.getToggle(toggleName));
         }
 
         @Override

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -1,17 +1,16 @@
 package io.getunleash;
 
+import static java.util.Collections.emptyList;
+
 import io.getunleash.lang.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 public class FakeUnleash implements Unleash {
     private boolean enableAll = false;
     private boolean disableAll = false;
-    private Map<String, Boolean> features = new HashMap<>();
+    private Map<String, FeatureToggle> features = new HashMap<>();
     private Map<String, Variant> variants = new HashMap<>();
 
     @Override
@@ -26,7 +25,9 @@ public class FakeUnleash implements Unleash {
         } else if (disableAll) {
             return false;
         } else {
-            return features.getOrDefault(toggleName, defaultSetting);
+            return more().getFeatureToggleDefinition(toggleName)
+                    .map(FeatureToggle::isEnabled)
+                    .orElse(defaultSetting);
         }
     }
 
@@ -102,13 +103,13 @@ public class FakeUnleash implements Unleash {
 
     public void enable(String... features) {
         for (String name : features) {
-            this.features.put(name, true);
+            this.features.put(name, new FeatureToggle(name, true, emptyList()));
         }
     }
 
     public void disable(String... features) {
         for (String name : features) {
-            this.features.put(name, false);
+            this.features.put(name, new FeatureToggle(name, false, emptyList()));
         }
     }
 
@@ -127,6 +128,11 @@ public class FakeUnleash implements Unleash {
         @Override
         public List<String> getFeatureToggleNames() {
             return new ArrayList<>(features.keySet());
+        }
+
+        @Override
+        public Optional<FeatureToggle> getFeatureToggleDefinition(String toggleName) {
+            return Optional.ofNullable(features.get(toggleName));
         }
 
         @Override

--- a/src/main/java/io/getunleash/MoreOperations.java
+++ b/src/main/java/io/getunleash/MoreOperations.java
@@ -1,10 +1,13 @@
 package io.getunleash;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MoreOperations {
 
     List<String> getFeatureToggleNames();
+
+    Optional<FeatureToggle> getFeatureToggleDefinition(String toggleName);
 
     List<EvaluatedToggle> evaluateAllToggles();
 

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class FakeUnleashTest {
@@ -99,6 +100,27 @@ public class FakeUnleashTest {
 
         List<String> expected = Arrays.asList(new String[] {"t1", "t2"});
         assertThat(fakeUnleash.more().getFeatureToggleNames()).containsAll(expected);
+    }
+
+    @Test
+    public void should_get_feature_definition() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.enable("t1");
+
+        Optional<FeatureToggle> optionalToggle =
+                fakeUnleash.more().getFeatureToggleDefinition("t1");
+        assertThat(optionalToggle).isPresent();
+
+        FeatureToggle toggle = optionalToggle.get();
+        assertThat(toggle.getName()).isEqualTo("t1");
+        assertThat(toggle.getStrategies()).isEmpty();
+        assertThat(toggle.isEnabled()).isTrue();
+    }
+
+    @Test
+    public void should_get_empty_optional_when_feature_definition_not_present() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        assertThat(fakeUnleash.more().getFeatureToggleDefinition("t1")).isEmpty();
     }
 
     @Test

--- a/src/test/java/io/getunleash/UnleashTest.java
+++ b/src/test/java/io/getunleash/UnleashTest.java
@@ -215,8 +215,7 @@ public class UnleashTest {
         FeatureToggle featureToggle = new FeatureToggle("test", false, asList(strategy1));
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(((DefaultUnleash) unleash).getFeatureToggleDefinition("test"))
-                .hasValue(featureToggle);
+        assertThat(unleash.more().getFeatureToggleDefinition("test")).hasValue(featureToggle);
     }
 
     @Test
@@ -225,8 +224,7 @@ public class UnleashTest {
         FeatureToggle featureToggle = new FeatureToggle("test", false, asList(strategy1));
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(((DefaultUnleash) unleash).getFeatureToggleDefinition("another toggleName"))
-                .isEmpty();
+        assertThat(unleash.more().getFeatureToggleDefinition("another toggleName")).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## About the changes
Adds `getFeatureToggleDefinition` to the interface so we don't need to refer to the concrete `DefaultUnleash` when we want to use that method.

The method was initially added in https://github.com/Unleash/unleash-client-java/pull/36

## Discussion points
Please let me know if there are any outstanding reasons this method should not be on the interface or if we'd like to expose the functionality in a different way. Thanks
