### PR TITLE
task: Make http agent timeouts configurable

### DIFF
--- a/src/main/java/io/getunleash/metric/UnleashMetricsSender.java
+++ b/src/main/java/io/getunleash/metric/UnleashMetricsSender.java
@@ -89,8 +89,8 @@ public class UnleashMetricsSender {
             } else {
                 connection = (HttpURLConnection) url.openConnection();
             }
-            connection.setConnectTimeout(CONNECT_TIMEOUT);
-            connection.setReadTimeout(CONNECT_TIMEOUT);
+            connection.setConnectTimeout((int) unleashConfig.getSendMetricsConnectTimeout().toMillis());
+            connection.setReadTimeout((int) unleashConfig.getSendMetricsReadTimeout().toMillis());
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Content-Type", "application/json");

--- a/src/main/java/io/getunleash/repository/HttpFeatureFetcher.java
+++ b/src/main/java/io/getunleash/repository/HttpFeatureFetcher.java
@@ -15,8 +15,6 @@ import org.slf4j.LoggerFactory;
 
 public class HttpFeatureFetcher implements FeatureFetcher {
     private static final Logger LOG = LoggerFactory.getLogger(HttpFeatureFetcher.class);
-
-    private static final int CONNECT_TIMEOUT = 10000;
     private Optional<String> etag = Optional.empty();
 
     private final UnleashConfig config;
@@ -107,8 +105,8 @@ public class HttpFeatureFetcher implements FeatureFetcher {
         } else {
             connection = (HttpURLConnection) url.openConnection();
         }
-        connection.setConnectTimeout(CONNECT_TIMEOUT);
-        connection.setReadTimeout(CONNECT_TIMEOUT);
+        connection.setConnectTimeout((int) this.config.getFetchTogglesConnectTimeout().toMillis());
+        connection.setReadTimeout((int) this.config.getFetchTogglesReadTimeout().toMillis());
         connection.setRequestProperty("Accept", "application/json");
         connection.setRequestProperty("Content-Type", "application/json");
         UnleashConfig.setRequestProperties(connection, this.config);

--- a/src/main/java/io/getunleash/repository/OkHttpFeatureFetcher.java
+++ b/src/main/java/io/getunleash/repository/OkHttpFeatureFetcher.java
@@ -19,10 +19,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 
 public class OkHttpFeatureFetcher implements FeatureFetcher {
-
-    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
-    private static final Duration CALL_TIMEOUT = Duration.ofSeconds(5);
-
     private final HttpUrl toggleUrl;
     private final OkHttpClient client;
 
@@ -34,8 +30,8 @@ public class OkHttpFeatureFetcher implements FeatureFetcher {
         }
         OkHttpClient.Builder builder =
                 new OkHttpClient.Builder()
-                        .connectTimeout(CONNECT_TIMEOUT)
-                        .callTimeout(CALL_TIMEOUT)
+                        .connectTimeout(unleashConfig.getFetchTogglesConnectTimeout())
+                        .callTimeout(unleashConfig.getFetchTogglesReadTimeout())
                         .followRedirects(true);
         if (tempDir != null) {
             builder = builder.cache(new Cache(tempDir, 1024 * 1024 * 50));

--- a/src/main/java/io/getunleash/util/UnleashConfig.java
+++ b/src/main/java/io/getunleash/util/UnleashConfig.java
@@ -20,6 +20,7 @@ import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -43,7 +44,15 @@ public class UnleashConfig {
     @Nullable private final String projectName;
     @Nullable private final String namePrefix;
     private final long fetchTogglesInterval;
+
+    private final Duration fetchTogglesConnectTimeout;
+
+    private final Duration fetchTogglesReadTimeout;
     private final long sendMetricsInterval;
+
+    private final Duration sendMetricsConnectTimeout;
+
+    private final Duration sendMetricsReadTimeout;
     private final boolean disableMetrics;
     private final boolean isProxyAuthenticationByJvmProperties;
     private final UnleashFeatureFetcherFactory unleashFeatureFetcherFactory;
@@ -67,7 +76,11 @@ public class UnleashConfig {
             @Nullable String projectName,
             @Nullable String namePrefix,
             long fetchTogglesInterval,
+            Duration fetchTogglesConnectTimeout,
+            Duration fetchTogglesReadTimeout,
             long sendMetricsInterval,
+            Duration sendMetricsConnectTimeout,
+            Duration sendMetricsReadTimeout,
             boolean disableMetrics,
             UnleashContextProvider contextProvider,
             boolean isProxyAuthenticationByJvmProperties,
@@ -124,7 +137,11 @@ public class UnleashConfig {
         this.projectName = projectName;
         this.namePrefix = namePrefix;
         this.fetchTogglesInterval = fetchTogglesInterval;
+        this.fetchTogglesConnectTimeout = fetchTogglesConnectTimeout;
+        this.fetchTogglesReadTimeout = fetchTogglesReadTimeout;
         this.sendMetricsInterval = sendMetricsInterval;
+        this.sendMetricsConnectTimeout = sendMetricsConnectTimeout;
+        this.sendMetricsReadTimeout = sendMetricsReadTimeout;
         this.disableMetrics = disableMetrics;
         this.contextProvider = contextProvider;
         this.isProxyAuthenticationByJvmProperties = isProxyAuthenticationByJvmProperties;
@@ -198,8 +215,24 @@ public class UnleashConfig {
         return fetchTogglesInterval;
     }
 
+    public Duration getFetchTogglesConnectTimeout() {
+        return fetchTogglesConnectTimeout;
+    }
+
+    public Duration getFetchTogglesReadTimeout() {
+        return fetchTogglesReadTimeout;
+    }
+
     public long getSendMetricsInterval() {
         return sendMetricsInterval;
+    }
+
+    public Duration getSendMetricsConnectTimeout() {
+        return sendMetricsConnectTimeout;
+    }
+
+    public Duration getSendMetricsReadTimeout() {
+        return sendMetricsReadTimeout;
     }
 
     public UnleashURLs getUnleashURLs() {
@@ -325,7 +358,15 @@ public class UnleashConfig {
         private @Nullable String projectName;
         private @Nullable String namePrefix;
         private long fetchTogglesInterval = 10;
+
+        private Duration fetchTogglesConnectTimeout = Duration.ofSeconds(10);
+
+        private Duration fetchTogglesReadTimeout = Duration.ofSeconds(10);
         private long sendMetricsInterval = 60;
+
+        private Duration sendMetricsConnectTimeout = Duration.ofSeconds(10);
+
+        private Duration sendMetricsReadTimeout = Duration.ofSeconds(10);
         private boolean disableMetrics = false;
         private UnleashFeatureFetcherFactory unleashFeatureFetcherFactory = HttpFeatureFetcher::new;
         private UnleashContextProvider contextProvider =
@@ -410,10 +451,50 @@ public class UnleashConfig {
             return this;
         }
 
+        public Builder fetchTogglesConnectTimeout(Duration connectTimeout) {
+            this.fetchTogglesConnectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder fetchTogglesConnectTimeoutSeconds(long connectTimeoutSeconds) {
+            this.fetchTogglesConnectTimeout = Duration.ofSeconds(connectTimeoutSeconds);
+            return this;
+        }
+        public Builder fetchTogglesReadTimeout(Duration readTimeout) {
+            this.fetchTogglesReadTimeout = readTimeout;
+            return this;
+        }
+
+        public Builder fetchTogglesReadTimeoutSeconds(long readTimeoutSeconds) {
+            this.fetchTogglesReadTimeout = Duration.ofSeconds(readTimeoutSeconds);
+            return this;
+        }
+
         public Builder sendMetricsInterval(long sendMetricsInterval) {
             this.sendMetricsInterval = sendMetricsInterval;
             return this;
         }
+
+        public Builder sendMetricsConnectTimeout(Duration connectTimeout) {
+            this.sendMetricsConnectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder sendMetricsConnectTimeoutSeconds(long connectTimeoutSeconds) {
+            this.sendMetricsConnectTimeout = Duration.ofSeconds(connectTimeoutSeconds);
+            return this;
+        }
+        public Builder sendMetricsReadTimeout(Duration readTimeout) {
+            this.sendMetricsReadTimeout = readTimeout;
+            return this;
+        }
+
+        public Builder sendMetricsReadTimeoutSeconds(long readTimeoutSeconds) {
+            this.sendMetricsReadTimeout = Duration.ofSeconds(readTimeoutSeconds);
+            return this;
+        }
+
+
 
         public Builder disableMetrics() {
             this.disableMetrics = true;
@@ -499,7 +580,11 @@ public class UnleashConfig {
                     projectName,
                     namePrefix,
                     fetchTogglesInterval,
+                    fetchTogglesConnectTimeout,
+                    fetchTogglesReadTimeout,
                     sendMetricsInterval,
+                    sendMetricsConnectTimeout,
+                    sendMetricsReadTimeout,
                     disableMetrics,
                     contextProvider,
                     isProxyAuthenticationByJvmProperties,


### PR DESCRIPTION
This PR makes connect and read timeouts for our http requests configurable, previously they've been hardcoded.
fixes: #163
