### PR TITLE
Task/adhere to newest client spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <version>6.0.3-SNAPSHOT</version>
 
     <properties>
-        <version.slf4j>1.7.36</version.slf4j>
+        <version.slf4j>2.0.3</version.slf4j>
         <version.log4j2>2.17.2</version.log4j2>
         <version.junit5>5.9.0</version.junit5>
         <version.okhttp>4.10.0</version.okhttp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.unleash.specification>4.2.0</version.unleash.specification>
+        <version.unleash.specification>4.2.2</version.unleash.specification>
         <arguments />
         <version.jackson>2.13.4</version.jackson>
     </properties>
@@ -111,13 +111,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.6.1</version>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.34.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <properties>
         <version.slf4j>2.0.3</version.slf4j>
-        <version.log4j2>2.17.2</version.log4j2>
+        <version.log4j2>2.19.0</version.log4j2>
         <version.junit5>5.9.0</version.junit5>
         <version.okhttp>4.10.0</version.okhttp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -139,13 +139,6 @@
             <scope>test</scope>
         </dependency>
 
-
-        <dependency>
-            <groupId>com.github.JensPiegsa</groupId>
-            <artifactId>wiremock-extension</artifactId>
-            <version>0.4.0</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>

--- a/src/main/java/io/getunleash/Segment.java
+++ b/src/main/java/io/getunleash/Segment.java
@@ -1,5 +1,8 @@
 package io.getunleash;
 
+import static java.util.Arrays.asList;
+
+import java.util.Collections;
 import java.util.List;
 
 public class Segment {
@@ -36,4 +39,14 @@ public class Segment {
     public void setConstraints(List<Constraint> constraints) {
         this.constraints = constraints;
     }
+
+    public static Segment DENY_SEGMENT =
+            new Segment(
+                    -9999,
+                    "NON_EXISTING_SEGMENT_ID",
+                    asList(
+                            new Constraint(
+                                    "non-existing-segment-id",
+                                    Operator.IN,
+                                    Collections.emptyList())));
 }

--- a/src/main/java/io/getunleash/repository/FeatureRepository.java
+++ b/src/main/java/io/getunleash/repository/FeatureRepository.java
@@ -127,6 +127,11 @@ public class FeatureRepository implements IFeatureRepository {
 
     @Override
     public Segment getSegment(Integer id) {
-        return featureCollection.getSegmentCollection().getSegment(id);
+        Segment seg = featureCollection.getSegmentCollection().getSegment(id);
+        if (seg == null) {
+            return Segment.DENY_SEGMENT;
+        } else {
+            return seg;
+        }
     }
 }

--- a/src/test/java/io/getunleash/event/SubscriberTest.java
+++ b/src/test/java/io/getunleash/event/SubscriberTest.java
@@ -1,15 +1,10 @@
 package io.getunleash.event;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static io.getunleash.repository.FeatureToggleResponse.Status.*;
+import static io.getunleash.repository.FeatureToggleResponse.Status.UNAVAILABLE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
-import com.github.jenspiegsa.wiremockextension.WireMockSettings;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.getunleash.DefaultUnleash;
 import io.getunleash.SynchronousTestExecutor;
 import io.getunleash.Unleash;
@@ -22,15 +17,15 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(WireMockExtension.class)
-@WireMockSettings(failOnUnmatchedRequests = false)
 public class SubscriberTest {
 
-    @ConfigureWireMock Options options = wireMockConfig().dynamicPort();
-
-    @InjectServer WireMockServer serverMock;
+    @RegisterExtension
+    static WireMockExtension serverMock =
+            WireMockExtension.newInstance()
+                    .options(wireMockConfig().dynamicPort().dynamicHttpsPort())
+                    .build();
 
     private TestSubscriber testSubscriber = new TestSubscriber();
     private UnleashConfig unleashConfig;
@@ -42,7 +37,7 @@ public class SubscriberTest {
                         .appName(SubscriberTest.class.getSimpleName())
                         .instanceId(SubscriberTest.class.getSimpleName())
                         .synchronousFetchOnInitialisation(true)
-                        .unleashAPI("http://localhost:" + serverMock.port())
+                        .unleashAPI("http://localhost:" + serverMock.getPort())
                         .subscriber(testSubscriber)
                         .scheduledExecutor(new SynchronousTestExecutor())
                         .build();

--- a/src/test/java/io/getunleash/integration/ClientSpecificationTest.java
+++ b/src/test/java/io/getunleash/integration/ClientSpecificationTest.java
@@ -1,16 +1,16 @@
 package io.getunleash.integration;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
-import com.github.jenspiegsa.wiremockextension.WireMockSettings;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import io.getunleash.DefaultUnleash;
@@ -34,15 +34,16 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(WireMockExtension.class)
-@WireMockSettings(failOnUnmatchedRequests = false)
 public class ClientSpecificationTest {
 
-    @ConfigureWireMock Options options = wireMockConfig().dynamicPort();
-
-    @InjectServer WireMockServer serverMock;
+    @RegisterExtension
+    static WireMockExtension serverMock =
+            WireMockExtension.newInstance()
+                    .configureStaticDsl(true)
+                    .options(wireMockConfig().dynamicPort().dynamicHttpsPort())
+                    .build();
 
     @TestFactory
     public Stream<DynamicTest> clientSpecification() throws IOException, URISyntaxException {
@@ -126,7 +127,7 @@ public class ClientSpecificationTest {
         UnleashConfig config =
                 UnleashConfig.builder()
                         .appName(testDefinition.getName())
-                        .unleashAPI(new URI("http://localhost:" + serverMock.port() + "/api/"))
+                        .unleashAPI(new URI("http://localhost:" + serverMock.getPort() + "/api/"))
                         .synchronousFetchOnInitialisation(true)
                         .backupFile(backupFile)
                         .build();

--- a/src/test/java/io/getunleash/metric/UnleashMetricsSenderTest.java
+++ b/src/test/java/io/getunleash/metric/UnleashMetricsSenderTest.java
@@ -1,30 +1,32 @@
 package io.getunleash.metric;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
-import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
-import com.github.jenspiegsa.wiremockextension.WireMockSettings;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.getunleash.util.UnleashConfig;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(WireMockExtension.class)
-@WireMockSettings(failOnUnmatchedRequests = false)
 public class UnleashMetricsSenderTest {
 
-    @ConfigureWireMock Options options = wireMockConfig().dynamicPort();
-
-    @InjectServer WireMockServer serverMock;
+    @RegisterExtension
+    static WireMockExtension serverMock =
+            WireMockExtension.newInstance()
+                    .configureStaticDsl(true)
+                    .options(wireMockConfig().dynamicPort().dynamicHttpsPort())
+                    .build();
 
     @Test
     public void should_send_client_registration() throws URISyntaxException {
@@ -33,7 +35,7 @@ public class UnleashMetricsSenderTest {
                         .withHeader("UNLEASH-APPNAME", matching("test-app"))
                         .willReturn(aResponse().withStatus(200)));
 
-        URI uri = new URI("http://localhost:" + serverMock.port());
+        URI uri = new URI("http://localhost:" + serverMock.getPort());
         UnleashConfig config = UnleashConfig.builder().appName("test-app").unleashAPI(uri).build();
 
         UnleashMetricsSender sender = new UnleashMetricsSender(config);
@@ -54,7 +56,7 @@ public class UnleashMetricsSenderTest {
                         .withHeader("UNLEASH-APPNAME", matching("test-app"))
                         .willReturn(aResponse().withStatus(200)));
 
-        URI uri = new URI("http://localhost:" + serverMock.port());
+        URI uri = new URI("http://localhost:" + serverMock.getPort());
         UnleashConfig config = UnleashConfig.builder().appName("test-app").unleashAPI(uri).build();
 
         UnleashMetricsSender sender = new UnleashMetricsSender(config);
@@ -76,7 +78,7 @@ public class UnleashMetricsSenderTest {
                         .withHeader("UNLEASH-APPNAME", matching("test-app"))
                         .willReturn(aResponse().withStatus(500)));
 
-        URI uri = new URI("http://localhost:" + serverMock.port());
+        URI uri = new URI("http://localhost:" + serverMock.getPort());
         UnleashConfig config = UnleashConfig.builder().appName("test-app").unleashAPI(uri).build();
 
         UnleashMetricsSender sender = new UnleashMetricsSender(config);

--- a/src/test/java/io/getunleash/repository/HttpFeatureFetcherTest.java
+++ b/src/test/java/io/getunleash/repository/HttpFeatureFetcherTest.java
@@ -1,16 +1,19 @@
 package io.getunleash.repository;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
-import com.github.jenspiegsa.wiremockextension.WireMockSettings;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.getunleash.FeatureToggle;
 import io.getunleash.util.UnleashConfig;
 import java.net.HttpURLConnection;
@@ -19,22 +22,26 @@ import java.net.URISyntaxException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@ExtendWith(WireMockExtension.class)
-@WireMockSettings(failOnUnmatchedRequests = false)
 public class HttpFeatureFetcherTest {
 
-    @ConfigureWireMock Options options = wireMockConfig().dynamicPort();
-    @InjectServer WireMockServer serverMock;
+    @RegisterExtension
+    static WireMockExtension serverMock =
+            WireMockExtension.newInstance()
+                    .configureStaticDsl(true)
+                    .options(wireMockConfig().dynamicPort())
+                    .build();
+
     HttpFeatureFetcher fetcher;
     URI uri;
 
     @BeforeEach
     void setUp() {
         try {
-            uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+            uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
@@ -170,7 +177,7 @@ public class HttpFeatureFetcherTest {
                                         .withHeader(
                                                 "Location",
                                                 "http://localhost:"
-                                                        + serverMock.port()
+                                                        + serverMock.getPort()
                                                         + "/api/v2/client/features")));
         serverMock.stubFor(
                 get(urlEqualTo("/api/v2/client/features"))

--- a/src/test/java/io/getunleash/repository/HttpToggleFetcherTest.java
+++ b/src/test/java/io/getunleash/repository/HttpToggleFetcherTest.java
@@ -1,16 +1,19 @@
 package io.getunleash.repository;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
-import com.github.jenspiegsa.wiremockextension.WireMockSettings;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.getunleash.FeatureToggle;
 import io.getunleash.util.UnleashConfig;
 import java.net.HttpURLConnection;
@@ -18,16 +21,18 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@ExtendWith(WireMockExtension.class)
-@WireMockSettings(failOnUnmatchedRequests = false)
 public class HttpToggleFetcherTest {
 
-    @ConfigureWireMock Options options = wireMockConfig().dynamicPort();
-
-    @InjectServer WireMockServer serverMock;
+    @RegisterExtension
+    static WireMockExtension serverMock =
+            WireMockExtension.newInstance()
+                    .configureStaticDsl(true)
+                    .options(wireMockConfig().dynamicPort())
+                    .build();
 
     /*
     @Test
@@ -59,7 +64,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v0.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -83,7 +88,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -107,7 +112,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1-with-variants.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -143,7 +148,7 @@ public class HttpToggleFetcherTest {
                                         .withStatus(304)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
 
@@ -165,7 +170,7 @@ public class HttpToggleFetcherTest {
                                         .withStatus(200)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         httpToggleFetcher.fetchToggles();
@@ -187,7 +192,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBody("{}")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         httpToggleFetcher.fetchToggles();
@@ -207,7 +212,7 @@ public class HttpToggleFetcherTest {
                                         .withStatus(304)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -235,7 +240,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader(
                                                 "Location",
                                                 "http://localhost:"
-                                                        + serverMock.port()
+                                                        + serverMock.getPort()
                                                         + "/api/v2/client/features")));
         stubFor(
                 get(urlEqualTo("/api/v2/client/features"))
@@ -246,7 +251,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -271,7 +276,7 @@ public class HttpToggleFetcherTest {
                                         .withStatus(httpCode)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -294,7 +299,7 @@ public class HttpToggleFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();
@@ -312,7 +317,7 @@ public class HttpToggleFetcherTest {
                                         .withStatus(308)
                                         .withHeader("Location", "https://unleash.com")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         HttpToggleFetcher httpToggleFetcher = new HttpToggleFetcher(config);
         FeatureToggleResponse response = httpToggleFetcher.fetchToggles();

--- a/src/test/java/io/getunleash/repository/OkHttpFeatureFetcherTest.java
+++ b/src/test/java/io/getunleash/repository/OkHttpFeatureFetcherTest.java
@@ -124,7 +124,7 @@ public class OkHttpFeatureFetcherTest {
         // Second fetch
         stubFor(
                 get(urlEqualTo("/api/client/features"))
-                        .withHeader("If-None-Match", equalTo("AZ12--gzip"))
+                        .withHeader("If-None-Match", equalTo("AZ12"))
                         .willReturn(
                                 aResponse()
                                         .withStatus(304)
@@ -142,7 +142,7 @@ public class OkHttpFeatureFetcherTest {
         verify(
                 1,
                 getRequestedFor(urlEqualTo("/api/client/features"))
-                        .withHeader("If-None-Match", equalTo("AZ12--gzip")));
+                        .withHeader("If-None-Match", equalTo("AZ12")));
         assertThat(response1.getStatus()).isEqualTo(FeatureToggleResponse.Status.CHANGED);
         assertThat(response2.getStatus()).isEqualTo(FeatureToggleResponse.Status.NOT_CHANGED);
     }

--- a/src/test/java/io/getunleash/repository/OkHttpFeatureFetcherTest.java
+++ b/src/test/java/io/getunleash/repository/OkHttpFeatureFetcherTest.java
@@ -12,12 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.jenspiegsa.wiremockextension.ConfigureWireMock;
-import com.github.jenspiegsa.wiremockextension.InjectServer;
-import com.github.jenspiegsa.wiremockextension.WireMockExtension;
-import com.github.jenspiegsa.wiremockextension.WireMockSettings;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.getunleash.FeatureToggle;
 import io.getunleash.util.UnleashConfig;
 import java.net.HttpURLConnection;
@@ -25,15 +20,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@ExtendWith(WireMockExtension.class)
-@WireMockSettings(failOnUnmatchedRequests = false)
 public class OkHttpFeatureFetcherTest {
-    @ConfigureWireMock Options options = wireMockConfig().dynamicPort();
-
-    @InjectServer WireMockServer serverMock;
+    @RegisterExtension
+    static WireMockExtension serverMock =
+            WireMockExtension.newInstance()
+                    .configureStaticDsl(true)
+                    .options(wireMockConfig().dynamicPort())
+                    .build();
 
     @Test
     public void happy_path_test_version0() throws URISyntaxException {
@@ -46,7 +43,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v0.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         ClientFeaturesResponse response = okHttpToggleFetcher.fetchFeatures();
@@ -70,7 +67,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         FeatureToggleResponse response = okHttpToggleFetcher.fetchFeatures();
@@ -94,7 +91,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1-with-variants.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         FeatureToggleResponse response = okHttpToggleFetcher.fetchFeatures();
@@ -130,7 +127,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withStatus(304)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
 
@@ -158,7 +155,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withStatus(200)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         okHttpToggleFetcher.fetchFeatures();
@@ -180,7 +177,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBody("{}")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         okHttpToggleFetcher.fetchFeatures();
@@ -200,7 +197,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withStatus(304)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         FeatureToggleResponse response = okHttpToggleFetcher.fetchFeatures();
@@ -228,7 +225,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader(
                                                 "Location",
                                                 "http://localhost:"
-                                                        + serverMock.port()
+                                                        + serverMock.getPort()
                                                         + "/api/v2/client/features")));
         stubFor(
                 get(urlEqualTo("/api/v2/client/features"))
@@ -239,7 +236,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         FeatureToggleResponse response = okHttpToggleFetcher.fetchFeatures();
@@ -264,7 +261,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withStatus(httpCode)
                                         .withHeader("Content-Type", "application/json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         FeatureToggleResponse response = okHttpToggleFetcher.fetchFeatures();
@@ -287,7 +284,7 @@ public class OkHttpFeatureFetcherTest {
                                         .withHeader("Content-Type", "application/json")
                                         .withBodyFile("features-v1.json")));
 
-        URI uri = new URI("http://localhost:" + serverMock.port() + "/api/");
+        URI uri = new URI("http://localhost:" + serverMock.getPort() + "/api/");
         UnleashConfig config = UnleashConfig.builder().appName("test").unleashAPI(uri).build();
         OkHttpFeatureFetcher okHttpToggleFetcher = new OkHttpFeatureFetcher(config);
         FeatureToggleResponse response = okHttpToggleFetcher.fetchFeatures();


### PR DESCRIPTION
So, for missing segments. That is, a feature that refers to a segment that does not exist in the global segments list, we should evaluate this to false. This PR fixes that, by adding a static Segment which is a single constraint requiring a named context field to have a value that is IN an empty list (an impossibility), which means it always evaluates to false.

In addition, I upgraded our WireMock usage to the most recent version and stopped using an ancient version of an addition JUnit 5 extension. Now we only use Wiremock's included JUnit5 extension.

From slack:
```
Simon Hornby: Yeah that test is for missing, not empty. So when the server says "go look up segment 18" and there is no segment 18 but there should be we should evaluate to false
```
