### PR TITLE
chorus: using more semantic java interface

### DIFF
--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -4,7 +4,7 @@ import static java.util.Collections.emptyList;
 
 import io.getunleash.lang.Nullable;
 import java.util.*;
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 public class FakeUnleash implements Unleash {
@@ -35,15 +35,15 @@ public class FakeUnleash implements Unleash {
     public boolean isEnabled(
             String toggleName,
             UnleashContext context,
-            BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+            BiPredicate<String, UnleashContext> fallbackAction) {
         return isEnabled(toggleName, fallbackAction);
     }
 
     @Override
     public boolean isEnabled(
-            String toggleName, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+            String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
         if (!features.containsKey(toggleName)) {
-            return fallbackAction.apply(toggleName, UnleashContext.builder().build());
+            return fallbackAction.test(toggleName, UnleashContext.builder().build());
         }
         return isEnabled(toggleName);
     }

--- a/src/main/java/io/getunleash/Unleash.java
+++ b/src/main/java/io/getunleash/Unleash.java
@@ -1,7 +1,7 @@
 package io.getunleash;
 
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 
 public interface Unleash {
     boolean isEnabled(String toggleName);
@@ -17,14 +17,14 @@ public interface Unleash {
     }
 
     default boolean isEnabled(
-            String toggleName, BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+            String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
         return isEnabled(toggleName, false);
     }
 
     default boolean isEnabled(
             String toggleName,
             UnleashContext context,
-            BiFunction<String, UnleashContext, Boolean> fallbackAction) {
+            BiPredicate<String, UnleashContext> fallbackAction) {
         return isEnabled(toggleName, context, false);
     }
 

--- a/src/test/java/io/getunleash/UnleashTest.java
+++ b/src/test/java/io/getunleash/UnleashTest.java
@@ -13,7 +13,7 @@ import io.getunleash.util.UnleashScheduledExecutor;
 import io.getunleash.variant.Payload;
 import io.getunleash.variant.VariantDefinition;
 import java.util.*;
-import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -79,33 +79,33 @@ public class UnleashTest {
     @Test
     public void fallback_function_should_be_invoked_and_return_true() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
-        BiFunction<String, UnleashContext, Boolean> fallbackAction = mock(BiFunction.class);
-        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(true);
+        BiPredicate<String, UnleashContext> fallbackAction = mock(BiPredicate.class);
+        when(fallbackAction.test(eq("test"), any(UnleashContext.class))).thenReturn(true);
 
         assertThat(unleash.isEnabled("test", fallbackAction)).isTrue();
-        verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
+        verify(fallbackAction, times(1)).test(anyString(), any(UnleashContext.class));
     }
 
     @Test
     public void fallback_function_should_be_invoked_also_with_context() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
-        BiFunction<String, UnleashContext, Boolean> fallbackAction = mock(BiFunction.class);
-        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(true);
+        BiPredicate<String, UnleashContext> fallbackAction = mock(BiPredicate.class);
+        when(fallbackAction.test(eq("test"), any(UnleashContext.class))).thenReturn(true);
 
         UnleashContext context = UnleashContext.builder().userId("123").build();
 
         assertThat(unleash.isEnabled("test", context, fallbackAction)).isTrue();
-        verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
+        verify(fallbackAction, times(1)).test(anyString(), any(UnleashContext.class));
     }
 
     @Test
     void fallback_function_should_be_invoked_and_return_false() {
         when(toggleRepository.getToggle("test")).thenReturn(null);
-        BiFunction<String, UnleashContext, Boolean> fallbackAction = mock(BiFunction.class);
-        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(false);
+        BiPredicate<String, UnleashContext> fallbackAction = mock(BiPredicate.class);
+        when(fallbackAction.test(eq("test"), any(UnleashContext.class))).thenReturn(false);
 
         assertThat(unleash.isEnabled("test", fallbackAction)).isFalse();
-        verify(fallbackAction, times(1)).apply(anyString(), any(UnleashContext.class));
+        verify(fallbackAction, times(1)).test(anyString(), any(UnleashContext.class));
     }
 
     @Test
@@ -115,11 +115,11 @@ public class UnleashTest {
                         new FeatureToggle(
                                 "test", true, asList(new ActivationStrategy("default", null))));
 
-        BiFunction<String, UnleashContext, Boolean> fallbackAction = mock(BiFunction.class);
-        when(fallbackAction.apply(eq("test"), any(UnleashContext.class))).thenReturn(false);
+        BiPredicate<String, UnleashContext> fallbackAction = mock(BiPredicate.class);
+        when(fallbackAction.test(eq("test"), any(UnleashContext.class))).thenReturn(false);
 
         assertThat(unleash.isEnabled("test", fallbackAction)).isTrue();
-        verify(fallbackAction, never()).apply(anyString(), any(UnleashContext.class));
+        verify(fallbackAction, never()).test(anyString(), any(UnleashContext.class));
     }
 
     @Test


### PR DESCRIPTION
using more semantic java functional interface `BiPredicate` instead of `BiFunction`.

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

Has potential to break compatibility with previous versions (see [Discussion points](#Discussion-points)), but makes the code more semantic.

<!-- Does it close an issue? Multiple? -->

Closes #176.

<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->

<!-- Relates to roadmap item:  -->

### Important files

- src/main/java/io/getunleash/Unleash.java
- src/test/java/io/getunleash/UnleashTest.java

## Discussion points

This might break some API consumers if they are using directly the interface `BiFunction` instead of a lambda.