### PR TITLE
fix: app name with slash or backslash

### DIFF
--- a/src/main/java/io/getunleash/util/UnleashConfig.java
+++ b/src/main/java/io/getunleash/util/UnleashConfig.java
@@ -602,8 +602,18 @@ public class UnleashConfig {
             if (backupFile != null) {
                 return backupFile;
             } else {
-                String fileName = "unleash-" + appName + "-repo.json";
-                return System.getProperty("java.io.tmpdir") + File.separatorChar + fileName;
+                String fileName = "unleash-" + sanitizedAppName(appName) + "-repo.json";
+                String tmpDir = System.getProperty("java.io.tmpdir");
+                tmpDir = (!tmpDir.endsWith(String.valueOf(File.separatorChar))) ? tmpDir + File.separatorChar : tmpDir;
+                return tmpDir + fileName;
+            }
+        }
+
+        private String sanitizedAppName(String appName) {
+            if (appName.contains("/") || appName.contains("\\")) {
+                return appName.replace("/", "-").replace("\\", "-");
+            } else {
+                return appName;
             }
         }
 

--- a/src/test/java/io/getunleash/util/UnleashConfigTest.java
+++ b/src/test/java/io/getunleash/util/UnleashConfigTest.java
@@ -68,6 +68,34 @@ public class UnleashConfigTest {
     }
 
     @Test
+    public void should_generate_backupfile_app_name_with_slash() {
+        UnleashConfig config =
+                UnleashConfig.builder().appName("fix/baz-123456").unleashAPI("http://unleash.org").build();
+
+        assertThat(config.getAppName()).isEqualTo("fix/baz-123456");
+        assertThat(config.getBackupFile())
+                .isEqualTo(
+                        System.getProperty("java.io.tmpdir")
+                                + "unleash-"
+                                + "fix-baz-123456"
+                                + "-repo.json");
+    }
+
+    @Test
+    public void should_generate_backupfile_app_name_with_backslash() {
+        UnleashConfig config =
+                UnleashConfig.builder().appName("fix\\baz-123456").unleashAPI("http://unleash.org").build();
+
+        assertThat(config.getAppName()).isEqualTo("fix\\baz-123456");
+        assertThat(config.getBackupFile())
+                .isEqualTo(
+                        System.getProperty("java.io.tmpdir")
+                                + "unleash-"
+                                + "fix-baz-123456"
+                                + "-repo.json");
+    }
+
+    @Test
     public void should_use_provided_backupfile() {
         UnleashConfig config =
                 UnleashConfig.builder()


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
This PR removes slashes and backslashes from appName, as they cause issues on windows/linux. Both are replaced by "-".
Additionally a check is added to prevent a double (back)slash in some cases when reading `java.io.tmpdir`.

<!-- Does it close an issue? Multiple? -->
Closes #175 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
