### PR TITLE
fix: getVariant counts enabled or not

### DIFF
--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -178,6 +178,8 @@ public class DefaultUnleash implements Unleash {
                         ? VariantUtil.selectVariant(featureToggle, context, defaultValue)
                         : defaultValue;
         metricService.countVariant(toggleName, variant.getName());
+        // Should count yes/no also when getting variant.
+        metricService.count(toggleName, enabled);
         return variant;
     }
 


### PR DESCRIPTION
As a change from earlier, this now increments yes/no as well as which variant was received in the MetricsBucket.

To reflect behaviour of Node SDK from https://github.com/Unleash/unleash-client-node/commit/38f35e658a34c510b4d01f8dd33866ff1119d96e onwards.