### PR TITLE
Validate behaviour with empty variants

### DIFF
--- a/src/test/java/io/getunleash/repository/JsonFeatureToggleParserTest.java
+++ b/src/test/java/io/getunleash/repository/JsonFeatureToggleParserTest.java
@@ -98,8 +98,9 @@ public class JsonFeatureToggleParserTest {
         Reader content = getFileReader("/features-v1-with-variants.json");
         ToggleCollection toggleCollection = JsonToggleParser.fromJson(content);
 
-        assertThat(toggleCollection.getFeatures()).hasSize(2);
+        assertThat(toggleCollection.getFeatures()).hasSize(3);
         assertThat(toggleCollection.getToggle("Test.old").isEnabled()).isTrue();
+        assertThat(toggleCollection.getToggle("Test.empty").isEnabled()).isFalse();
         assertThat(toggleCollection.getToggle("Test.variants").isEnabled()).isTrue();
         assertThat(toggleCollection.getToggle("Test.variants").getVariants()).isNotNull();
         assertThat(toggleCollection.getToggle("Test.variants").getVariants()).hasSize(2);

--- a/src/test/resources/features-v1-with-variants.json
+++ b/src/test/resources/features-v1-with-variants.json
@@ -14,6 +14,18 @@
       "createdAt": "2019-01-24T10:38:10.370Z"
     },
     {
+      "name": "Test.empty",
+      "description": "Empty variants here!",
+      "enabled": true,
+      "strategies": [
+          {
+              "name": "default"
+          }
+      ],
+      "variants": [],
+      "createdAt": "2022-12-15T10:38:10.370Z"
+    },
+    {
       "name": "Test.variants",
       "description": null,
       "enabled": true,


### PR DESCRIPTION
## About the changes
This PR intends to test the behaviour when variants are empty. Related with https://github.com/Unleash/client-specification/pull/45

## Discussion points
What should be the right behaviour in this situation?