### PR TITLE
feat: proposal to change default methods in Unleash interface

### DIFF
--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -81,19 +81,8 @@ public class DefaultUnleash implements Unleash {
     }
 
     @Override
-    public boolean isEnabled(final String toggleName) {
-        return isEnabled(toggleName, false);
-    }
-
-    @Override
     public boolean isEnabled(final String toggleName, final boolean defaultSetting) {
         return isEnabled(toggleName, contextProvider.getContext(), defaultSetting);
-    }
-
-    @Override
-    public boolean isEnabled(
-            final String toggleName, final UnleashContext context, final boolean defaultSetting) {
-        return isEnabled(toggleName, context, (n, c) -> defaultSetting);
     }
 
     @Override

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -14,11 +14,6 @@ public class FakeUnleash implements Unleash {
     private Map<String, Variant> variants = new HashMap<>();
 
     @Override
-    public boolean isEnabled(String toggleName) {
-        return isEnabled(toggleName, false);
-    }
-
-    @Override
     public boolean isEnabled(String toggleName, boolean defaultSetting) {
         if (enableAll) {
             return true;

--- a/src/main/java/io/getunleash/Unleash.java
+++ b/src/main/java/io/getunleash/Unleash.java
@@ -4,38 +4,43 @@ import java.util.List;
 import java.util.function.BiPredicate;
 
 public interface Unleash {
-    boolean isEnabled(String toggleName);
+    default boolean isEnabled(String toggleName) {
+        return isEnabled(toggleName, false);
+    }
 
-    boolean isEnabled(String toggleName, boolean defaultSetting);
+    default boolean isEnabled(String toggleName, boolean defaultSetting) {
+        return isEnabled(toggleName, UnleashContext.builder().build(), defaultSetting);
+    }
 
     default boolean isEnabled(String toggleName, UnleashContext context) {
         return isEnabled(toggleName, context, false);
     }
 
     default boolean isEnabled(String toggleName, UnleashContext context, boolean defaultSetting) {
-        return isEnabled(toggleName, defaultSetting);
+        return isEnabled(toggleName, context, (n, c) -> defaultSetting);
     }
 
-    default boolean isEnabled(
-            String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
-        return isEnabled(toggleName, false);
+    default boolean isEnabled(String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
+        return isEnabled(toggleName, UnleashContext.builder().build(), fallbackAction);
     }
 
-    default boolean isEnabled(
+    boolean isEnabled(
             String toggleName,
             UnleashContext context,
-            BiPredicate<String, UnleashContext> fallbackAction) {
-        return isEnabled(toggleName, context, false);
-    }
+            BiPredicate<String, UnleashContext> fallbackAction);
 
     Variant getVariant(final String toggleName, final UnleashContext context);
 
     Variant getVariant(
             final String toggleName, final UnleashContext context, final Variant defaultValue);
 
-    Variant getVariant(final String toggleName);
+    default Variant getVariant(final String toggleName) {
+        return getVariant(toggleName, UnleashContext.builder().build());
+    }
 
-    Variant getVariant(final String toggleName, final Variant defaultValue);
+    default Variant getVariant(final String toggleName, final Variant defaultValue) {
+        return getVariant(toggleName, UnleashContext.builder().build(), defaultValue);
+    }
 
     /**
      * Use more().getFeatureToggleNames() instead


### PR DESCRIPTION
## About the changes
Proposal based on #181:
1. Adds default empty context to avoid having to deal with nulls
2. Transforms `false` into a default fallback action
3. Leaving `boolean isEnabled(String toggleName, UnleashContext context, BiPredicate<String, UnleashContext> fallbackAction)` as the only method that needs to be implemented 


