### PR TITLE
docs: merge Java doc with docs.getunleash content

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You need to add the Unleash SDK as a dependency for your project. Here's how you
 
 **⚠️ Important:** In almost every case, you only want a **single, shared instance of the `Unleash`  class (a *singleton*)** in your application . You would typically use a dependency injection framework (such as Spring or Guice) to inject it where you need it. Having multiple instances of the client in your application could lead to inconsistencies and performance degradation.
 
-To help you detect cases where you configure multiple instances by mistake, the SDK will print an error message if you create multiple instances with the same configuration values. You can also tell Unleash to fail when this happens by setting the constructor parameter `failOnMultipleInstantiations` to `true`
+To help you detect cases where you configure multiple instances by mistake, the SDK will print an error message if you create multiple instances with the same configuration values. You can also tell Unleash to fail when this happens by setting the constructor parameter `failOnMultipleInstantiations` to `true`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ UnleashConfig config = UnleashConfig.builder()
         .appName("my.java-app")
         .instanceId("your-instance-1")
         .unleashAPI("<unleash-api-url>")
-        .customHttpHeader("Authorization", "<client-api-token>")
+        .apiKey("<client-api-token>")
         .build();
 
 Unleash unleash = new DefaultUnleash(config);
@@ -66,7 +66,7 @@ UnleashConfig config = UnleashConfig.builder()
         .appName("my.java-app")
         .instanceId("your-instance-1")
         .unleashAPI("<unleash-api-url>")
-        .customHttpHeader("Authorization", "<client-api-token>")
+        .apiKey("<client-api-token>")
         .synchronousFetchOnInitialization(true)
         .build();
 
@@ -149,7 +149,7 @@ UnleashConfig config = new UnleashConfig.Builder()
             .appName("java-test")
             .instanceId("instance x")
             .unleashAPI("http://unleash.herokuapp.com/api/")
-            .customHttpHeader("Authorization", "API token")
+            .apiKey("<client-api-token>")
             .unleashContextProvider(contextProvider)
             .build();
 


### PR DESCRIPTION
## What

This change attempts to integrate all the information that currently
exists in the [docs.getunleash Java
doc](https://docs.getunleash.io/reference/sdks/java) into the readme.

It also updates some of the links to the doc from the old format to
the new format.

## Why

Having multiple versions of the same documentation can be confusing
and cause drift. We're moving to automatically generating the SDK
content on docs.getunleash now (from GitHub readmes), so it's
important to ensure that we don't lose any information in the process.