### PR TITLE
Make Backuphandler extensible

### DIFF
--- a/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
+++ b/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
@@ -11,19 +11,19 @@ import java.util.Collections;
 public abstract class AbstractBackupHandler implements BackupHandler<FeatureCollection> {
     private final EventDispatcher eventDispatcher;
 
-    public AbstractBackupHandler(final UnleashConfig config) {
+    public AbstractBackupHandler(UnleashConfig config) {
         this.eventDispatcher = new EventDispatcher(config);
     }
 
     @Override
     public FeatureCollection read() {
         try {
-            final FeatureCollection collection = readFeatureCollection();
+            FeatureCollection collection = readFeatureCollection();
 
             eventDispatcher.dispatch(new FeatureBackupRead(collection));
 
             return collection;
-        } catch (final UnleashException ex) {
+        } catch (UnleashException ex) {
             eventDispatcher.dispatch(ex);
         }
 
@@ -38,14 +38,14 @@ public abstract class AbstractBackupHandler implements BackupHandler<FeatureColl
             writeFeatureCollection(collection);
 
             eventDispatcher.dispatch(new FeatureBackupWritten(collection));
-        } catch (final UnleashException ex) {
+        } catch (UnleashException ex) {
             eventDispatcher.dispatch(ex);
         }
     }
 
     protected abstract FeatureCollection readFeatureCollection();
 
-    protected abstract void writeFeatureCollection(final FeatureCollection featureCollection);
+    protected abstract void writeFeatureCollection(FeatureCollection featureCollection);
 
 
     private static class FeatureBackupRead implements UnleashEvent {

--- a/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
+++ b/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
@@ -1,0 +1,82 @@
+package io.getunleash.repository;
+
+import io.getunleash.UnleashException;
+import io.getunleash.event.EventDispatcher;
+import io.getunleash.event.UnleashEvent;
+import io.getunleash.event.UnleashSubscriber;
+import io.getunleash.util.UnleashConfig;
+
+import java.util.Collections;
+
+public abstract class AbstractBackupHandler implements BackupHandler<FeatureCollection> {
+    private final EventDispatcher eventDispatcher;
+
+    public AbstractBackupHandler(final UnleashConfig config) {
+        this.eventDispatcher = new EventDispatcher(config);
+    }
+
+    @Override
+    public FeatureCollection read() {
+        try {
+            eventDispatcher.dispatch(new FeatureBackupRead(readFeatureCollection()));
+        } catch (final UnleashException ex) {
+            eventDispatcher.dispatch(ex);
+        } catch (final Exception ex) {
+            eventDispatcher.dispatch(
+                new UnleashException("Failed to read collection", ex));
+        }
+
+        return new FeatureCollection(
+            new ToggleCollection(Collections.emptyList()),
+            new SegmentCollection(Collections.emptyList()));
+    }
+
+    @Override
+    public void write(FeatureCollection collection) {
+        try {
+            writeFeatureCollection(collection);
+
+            eventDispatcher.dispatch(new FeatureBackupWritten(collection));
+        } catch (final UnleashException ex) {
+            eventDispatcher.dispatch(ex);
+        } catch (Exception e) {
+            eventDispatcher.dispatch(
+                new UnleashException(
+                    "Unleash was unable to backup feature toggles",
+                    e));
+        }
+    }
+
+    protected abstract FeatureCollection readFeatureCollection() throws Exception;
+
+    protected abstract void writeFeatureCollection(final FeatureCollection featureCollection) throws Exception;
+
+
+    private static class FeatureBackupRead implements UnleashEvent {
+
+        private final FeatureCollection featureCollection;
+
+        private FeatureBackupRead(FeatureCollection featureCollection) {
+            this.featureCollection = featureCollection;
+        }
+
+        @Override
+        public void publishTo(UnleashSubscriber unleashSubscriber) {
+            unleashSubscriber.featuresBackupRestored(featureCollection);
+        }
+    }
+
+    private static class FeatureBackupWritten implements UnleashEvent {
+
+        private final FeatureCollection featureCollection;
+
+        private FeatureBackupWritten(FeatureCollection featureCollection) {
+            this.featureCollection = featureCollection;
+        }
+
+        @Override
+        public void publishTo(UnleashSubscriber unleashSubscriber) {
+            unleashSubscriber.featuresBackedUp(featureCollection);
+        }
+    }
+}

--- a/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
+++ b/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
@@ -18,7 +18,11 @@ public abstract class AbstractBackupHandler implements BackupHandler<FeatureColl
     @Override
     public FeatureCollection read() {
         try {
-            eventDispatcher.dispatch(new FeatureBackupRead(readFeatureCollection()));
+            final FeatureCollection collection = readFeatureCollection();
+
+            eventDispatcher.dispatch(new FeatureBackupRead(collection));
+
+            return collection;
         } catch (final UnleashException ex) {
             eventDispatcher.dispatch(ex);
         } catch (final Exception ex) {

--- a/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
+++ b/src/main/java/io/getunleash/repository/AbstractBackupHandler.java
@@ -25,9 +25,6 @@ public abstract class AbstractBackupHandler implements BackupHandler<FeatureColl
             return collection;
         } catch (final UnleashException ex) {
             eventDispatcher.dispatch(ex);
-        } catch (final Exception ex) {
-            eventDispatcher.dispatch(
-                new UnleashException("Failed to read collection", ex));
         }
 
         return new FeatureCollection(
@@ -43,17 +40,12 @@ public abstract class AbstractBackupHandler implements BackupHandler<FeatureColl
             eventDispatcher.dispatch(new FeatureBackupWritten(collection));
         } catch (final UnleashException ex) {
             eventDispatcher.dispatch(ex);
-        } catch (Exception e) {
-            eventDispatcher.dispatch(
-                new UnleashException(
-                    "Unleash was unable to backup feature toggles",
-                    e));
         }
     }
 
-    protected abstract FeatureCollection readFeatureCollection() throws Exception;
+    protected abstract FeatureCollection readFeatureCollection();
 
-    protected abstract void writeFeatureCollection(final FeatureCollection featureCollection) throws Exception;
+    protected abstract void writeFeatureCollection(final FeatureCollection featureCollection);
 
 
     private static class FeatureBackupRead implements UnleashEvent {

--- a/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
+++ b/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
@@ -14,7 +14,7 @@ public class FeatureBackupHandlerFile extends AbstractBackupHandler {
 
     private final String backupFile;
 
-    public FeatureBackupHandlerFile(final UnleashConfig config) {
+    public FeatureBackupHandlerFile(UnleashConfig config) {
         super(config);
         this.backupFile = config.getBackupFile();
     }
@@ -22,17 +22,17 @@ public class FeatureBackupHandlerFile extends AbstractBackupHandler {
     @Override
     protected final FeatureCollection readFeatureCollection() {
         LOG.info("Unleash will try to load feature toggle states from temporary backup");
-        try (final FileReader reader = new FileReader(backupFile)) {
-            final BufferedReader br = new BufferedReader(reader);
+        try (FileReader reader = new FileReader(backupFile)) {
+            BufferedReader br = new BufferedReader(reader);
 
             return JsonFeatureParser.fromJson(br);
-        } catch (final FileNotFoundException e) {
+        } catch (FileNotFoundException e) {
             LOG.info(
                 " Unleash could not find the backup-file '"
                     + backupFile
                     + "'. \n"
                     + "This is expected behavior the first time unleash runs in a new environment.");
-        } catch (final IOException | IllegalStateException | JsonParseException e) {
+        } catch (IOException | IllegalStateException | JsonParseException e) {
             throw new UnleashException("Failed to read backup file: " + backupFile, e);
         }
 

--- a/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
+++ b/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
@@ -2,87 +2,57 @@ package io.getunleash.repository;
 
 import com.google.gson.JsonParseException;
 import io.getunleash.UnleashException;
-import io.getunleash.event.EventDispatcher;
-import io.getunleash.event.UnleashEvent;
-import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.util.UnleashConfig;
-import java.io.*;
-import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FeatureBackupHandlerFile implements BackupHandler<FeatureCollection> {
+import java.io.*;
+import java.util.Collections;
+
+public class FeatureBackupHandlerFile extends AbstractBackupHandler {
     private static final Logger LOG = LoggerFactory.getLogger(FeatureBackupHandlerFile.class);
 
     private final String backupFile;
-    private final EventDispatcher eventDispatcher;
 
-    public FeatureBackupHandlerFile(UnleashConfig config) {
+    public FeatureBackupHandlerFile(final UnleashConfig config) {
+        super(config);
         this.backupFile = config.getBackupFile();
-        this.eventDispatcher = new EventDispatcher(config);
     }
 
     @Override
-    public FeatureCollection read() {
+    protected final FeatureCollection readFeatureCollection() throws Exception {
         LOG.info("Unleash will try to load feature toggle states from temporary backup");
-        try (FileReader reader = new FileReader(backupFile)) {
-            BufferedReader br = new BufferedReader(reader);
-            FeatureCollection featureCollection = JsonFeatureParser.fromJson(br);
-            eventDispatcher.dispatch(new FeatureBackupRead(featureCollection));
-            return featureCollection;
-        } catch (FileNotFoundException e) {
+        try (final FileReader reader = new FileReader(backupFile)) {
+            final BufferedReader br = new BufferedReader(reader);
+
+            return JsonFeatureParser.fromJson(br);
+        } catch (final FileNotFoundException e) {
             LOG.info(
-                    " Unleash could not find the backup-file '"
-                            + backupFile
-                            + "'. \n"
-                            + "This is expected behavior the first time unleash runs in a new environment.");
-        } catch (IOException | IllegalStateException | JsonParseException e) {
-            eventDispatcher.dispatch(
-                    new UnleashException("Failed to read backup file: " + backupFile, e));
+                " Unleash could not find the backup-file '"
+                    + backupFile
+                    + "'. \n"
+                    + "This is expected behavior the first time unleash runs in a new environment.");
+        } catch (final IOException | IllegalStateException | JsonParseException e) {
+            throw new UnleashException("Failed to read backup file: " + backupFile, e);
         }
+
         return new FeatureCollection(
-                new ToggleCollection(Collections.emptyList()),
-                new SegmentCollection(Collections.emptyList()));
+            new ToggleCollection(Collections.emptyList()),
+            new SegmentCollection(Collections.emptyList()));
     }
 
     @Override
-    public void write(FeatureCollection featureCollection) {
-        try (FileWriter writer = new FileWriter(backupFile)) {
+    protected final void writeFeatureCollection(final FeatureCollection featureCollection) throws Exception {
+        try (final FileWriter writer = new FileWriter(backupFile)) {
             writer.write(JsonFeatureParser.toJsonString(featureCollection));
-            eventDispatcher.dispatch(new FeatureBackupWritten(featureCollection));
         } catch (IOException e) {
-            eventDispatcher.dispatch(
-                    new UnleashException(
-                            "Unleash was unable to backup feature toggles to file: " + backupFile,
-                            e));
-        }
-    }
-
-    private static class FeatureBackupRead implements UnleashEvent {
-
-        private final FeatureCollection featureCollection;
-
-        private FeatureBackupRead(FeatureCollection featureCollection) {
-            this.featureCollection = featureCollection;
-        }
-
-        @Override
-        public void publishTo(UnleashSubscriber unleashSubscriber) {
-            unleashSubscriber.featuresBackupRestored(featureCollection);
-        }
-    }
-
-    private static class FeatureBackupWritten implements UnleashEvent {
-
-        private final FeatureCollection featureCollection;
-
-        private FeatureBackupWritten(FeatureCollection featureCollection) {
-            this.featureCollection = featureCollection;
-        }
-
-        @Override
-        public void publishTo(UnleashSubscriber unleashSubscriber) {
-            unleashSubscriber.featuresBackedUp(featureCollection);
+            throw
+                new UnleashException(
+                    "Unleash was unable to backup feature toggles to file: " + backupFile,
+                    e);
+        } catch (final IllegalStateException | JsonParseException e) {
+            throw
+                new UnleashException("Failed to read backup file: " + backupFile, e);
         }
     }
 }

--- a/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
+++ b/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
@@ -50,9 +50,6 @@ public class FeatureBackupHandlerFile extends AbstractBackupHandler {
                 new UnleashException(
                     "Unleash was unable to backup feature toggles to file: " + backupFile,
                     e);
-        } catch (final IllegalStateException | JsonParseException e) {
-            throw
-                new UnleashException("Failed to read backup file: " + backupFile, e);
         }
     }
 }

--- a/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
+++ b/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
@@ -43,7 +43,7 @@ public class FeatureBackupHandlerFile extends AbstractBackupHandler {
 
     @Override
     protected final void writeFeatureCollection(final FeatureCollection featureCollection) {
-        try (final FileWriter writer = new FileWriter(backupFile)) {
+        try (FileWriter writer = new FileWriter(backupFile)) {
             writer.write(JsonFeatureParser.toJsonString(featureCollection));
         } catch (IOException e) {
             throw

--- a/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
+++ b/src/main/java/io/getunleash/repository/FeatureBackupHandlerFile.java
@@ -20,7 +20,7 @@ public class FeatureBackupHandlerFile extends AbstractBackupHandler {
     }
 
     @Override
-    protected final FeatureCollection readFeatureCollection() throws Exception {
+    protected final FeatureCollection readFeatureCollection() {
         LOG.info("Unleash will try to load feature toggle states from temporary backup");
         try (final FileReader reader = new FileReader(backupFile)) {
             final BufferedReader br = new BufferedReader(reader);
@@ -42,7 +42,7 @@ public class FeatureBackupHandlerFile extends AbstractBackupHandler {
     }
 
     @Override
-    protected final void writeFeatureCollection(final FeatureCollection featureCollection) throws Exception {
+    protected final void writeFeatureCollection(final FeatureCollection featureCollection) {
         try (final FileWriter writer = new FileWriter(backupFile)) {
             writer.write(JsonFeatureParser.toJsonString(featureCollection));
         } catch (IOException e) {


### PR DESCRIPTION
Currently, a lot of code in FeatureBackupHandlerFile is not directly related to the type i.e if the type file back up or in-memory. If we need to write another type of BackupHandler, a lot of code like FeatureBackupRead and FeatureBackupWritten classes have to be repeated. Also, the code to publish the event has to be repeated.

Pull these code to a common code so that all BackupHandler implementations can re-use them

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

- Create an abstract class `AbstractBackupHandler` which has all the common code like the event classes FeatureBackupRead and FeatureBackupWritten. 
- Also pulled the code to publish the event to this abstract class.   
- Make FeatureBackupHandlerFile extend this abstract class

<!-- Does it close an issue? Multiple? -->
Closes #190 

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
