### PR TITLE
feat: Adds validate method to UnleashConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,29 @@ assertThat(fakeUnleash.getVariant("t1").getName(), is("a"));
 
 Se more in [FakeUnleashTest.java](https://github.com/Unleash/unleash-client-java/blob/main/src/test/java/io/getunleash/FakeUnleashTest.java)
 
+### Configuration validation
+**!   Note** Since v7.2.0
+
+Unleash is designed to be run as a client inside your code, great care has been taken to avoid throwing exceptions to avoid interrupting the flow of your application.
+Some users have uttered the need to have a way to ensure that their configuration is able to fetch feature toggles.
+
+v7.2.0 of this SDK adds a `validate()` method to the `UnleashConfig` class.
+This method will use the configuration to make a call to the configured Unleash server or throw an UnleashException if the call fails for any reason.
+If you're wrapping Unleash with your own library, you can use this when configuring your wrapper to ensure that your configuration is correct.
+
+```java
+UnleashConfig config = UnleashConfig.builder()
+    .appName("my-app")
+    .unleashAPI("http://unleash.org")
+    .apiKey("Authorization", "API token")
+    .build();
+try {
+    config.validate();
+} catch (UnleashException ue) {
+    LOG.error(ue);
+}
+```
+
 ## Development
 
 Build:

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -3,7 +3,6 @@ package io.getunleash;
 import static java.util.Collections.emptyList;
 
 import io.getunleash.lang.Nullable;
-
 import java.util.*;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
@@ -23,22 +22,22 @@ public class FakeUnleash implements Unleash {
             return excludedFeatures.getOrDefault(toggleName, false);
         } else {
             return more().getFeatureToggleDefinition(toggleName)
-                .map(FeatureToggle::isEnabled)
-                .orElse(defaultSetting);
+                    .map(FeatureToggle::isEnabled)
+                    .orElse(defaultSetting);
         }
     }
 
     @Override
     public boolean isEnabled(
-        String toggleName,
-        UnleashContext context,
-        BiPredicate<String, UnleashContext> fallbackAction) {
+            String toggleName,
+            UnleashContext context,
+            BiPredicate<String, UnleashContext> fallbackAction) {
         return isEnabled(toggleName, fallbackAction);
     }
 
     @Override
     public boolean isEnabled(
-        String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
+            String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
         if (!features.containsKey(toggleName)) {
             return fallbackAction.test(toggleName, UnleashContext.builder().build());
         }

--- a/src/main/java/io/getunleash/util/UnleashConfig.java
+++ b/src/main/java/io/getunleash/util/UnleashConfig.java
@@ -5,6 +5,7 @@ import static io.getunleash.DefaultUnleash.UNKNOWN_STRATEGY;
 import io.getunleash.CustomHttpHeadersProvider;
 import io.getunleash.DefaultCustomHttpHeadersProviderImpl;
 import io.getunleash.UnleashContextProvider;
+import io.getunleash.UnleashException;
 import io.getunleash.event.NoOpSubscriber;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.lang.Nullable;
@@ -183,6 +184,16 @@ public class UnleashConfig {
         // http.proxyUser http.proxyPassword is only consumed by Apache HTTP Client, for
         // HttpUrlConnection we have to define an Authenticator
         Authenticator.setDefault(new SystemProxyAuthenticator());
+    }
+
+    /**
+     * Fetches client features using this configuration.
+     * If the method does not throw, the configuration was able to fetch features and as such is assumed to be correct.
+     * Use upon initial building of an UnleashClient to simplify debugging and interrupting your application if client is incorrectly configured.
+     * @throws UnleashException Thrown if something went wrong when trying to fetch features. Typical errors are incorrect URLs or apiKeys
+     */
+    public void validate() throws UnleashException {
+        this.getUnleashFeatureFetcherFactory().apply(this).fetchFeatures();
     }
 
     public URI getUnleashAPI() {


### PR DESCRIPTION
User request to have a way to validate that configuration was correct that can actually interrupt controlflow. The Eventmodel wasn't suited for this, since the event dispatcher dispatches on a different thread to the callee. This adds a way to have the exception thrown on the main caller thread.