### PR TITLE
chore: proposal to have logs on our examples

### DIFF
--- a/examples/cli-example/build.gradle.kts
+++ b/examples/cli-example/build.gradle.kts
@@ -14,4 +14,5 @@ repositories {
 
 dependencies {
     implementation("io.getunleash:unleash-client-java:7.1.0")
+    implementation("ch.qos.logback:logback-classic:1.4.6")
 }

--- a/examples/cli-example/src/main/resources/logback.xml
+++ b/examples/cli-example/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## About the changes
Currently, our examples are not outputting logs. This uses logback-classic implementation.

## Discussion points
Should we introduce logback-classic as a dependency? There are other options, so there's no particular reason to choose logback, but I don't want this to be taken as a recommendation.