### PR TITLE
fix: Update random to 0-10000 instead of 0-100

### DIFF
--- a/src/main/java/io/getunleash/strategy/FlexibleRolloutStrategy.java
+++ b/src/main/java/io/getunleash/strategy/FlexibleRolloutStrategy.java
@@ -12,7 +12,7 @@ public class FlexibleRolloutStrategy implements Strategy {
     private Supplier<String> randomGenerator;
 
     public FlexibleRolloutStrategy() {
-        this.randomGenerator = () -> Math.random() * 100 + "";
+        this.randomGenerator = () -> Math.random() * 10000 + "";
     }
 
     public FlexibleRolloutStrategy(Supplier<String> randomGenerator) {


### PR DESCRIPTION
After thorough testing with Go, Java and Javascript the last few days, we've found that using 0-100 didn't give enough entropy to the first bytes of the hash bucket, causing odd distributions. This updates to using 10000 as the max range to increase entropy and reflect what we do in node (since January) and in go (since April).