### PR TITLE
task: Added workflow for releasing new versions from GHA

### DIFF
--- a/.github/workflows/release_to_central.yml
+++ b/.github/workflows/release_to_central.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout code
+        with:
+          token: ${{ secrets.GH_PUSH_TOKEN }}
       - name: Setup Java and Maven Central Repo
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release_to_central.yml
+++ b/.github/workflows/release_to_central.yml
@@ -6,6 +6,9 @@ on:
       version:
         description: What version would you like to use?
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_to_central.yml
+++ b/.github/workflows/release_to_central.yml
@@ -1,0 +1,36 @@
+name: Release to central
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: What version would you like to use?
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout code
+      - name: Setup Java and Maven Central Repo
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          cache: maven
+      - name: Setup git config
+        run: |
+          git config user.name "Github Release Bot"
+          git config user.email "<>"
+      - name: Release
+        run: mvn -B -DreleaseVersion=${{ inputs.version}} release:prepare release:perform
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+

--- a/.github/workflows/release_to_central.yml
+++ b/.github/workflows/release_to_central.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout code
-        with:
-          token: ${{ secrets.GH_PUSH_TOKEN }}
       - name: Setup Java and Maven Central Repo
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
If this works, it would make the workflow the same as we have for Unleash server. 
Trigger the workflow, type the desired version to release and wait. 