### PR TITLE
fix: when using multiple strategies some of them might not be evaluated

### DIFF
--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -202,7 +202,7 @@ public class DefaultUnleash implements Unleash {
                 }
             }
         }
-        return new FeatureEvaluationResult(enabled, null);
+        return new FeatureEvaluationResult(enabled, defaultVariant);
     }
 
     private void checkIfToggleMatchesNamePrefix(String toggleName) {

--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -171,38 +171,35 @@ public class DefaultUnleash implements Unleash {
         } else if (featureToggle.getStrategies().size() == 0) {
             enabled = true;
         } else {
-            for (ActivationStrategy strategy: featureToggle.getStrategies()) {
-                Strategy configuredStrategy =
-                    getStrategy(strategy.getName());
+            for (ActivationStrategy strategy : featureToggle.getStrategies()) {
+                Strategy configuredStrategy = getStrategy(strategy.getName());
                 if (configuredStrategy == UNKNOWN_STRATEGY) {
                     LOGGER.warn(
-                        "Unable to find matching strategy for toggle:{} strategy:{}",
-                        toggleName,
-                        strategy.getName());
+                            "Unable to find matching strategy for toggle:{} strategy:{}",
+                            toggleName,
+                            strategy.getName());
                 }
 
-                FeatureEvaluationResult result = configuredStrategy.getResult(
-                    strategy.getParameters(),
-                    enhancedContext,
-                    ConstraintMerger.mergeConstraints(
-                        featureRepository, strategy),
-                    strategy.getVariants());
+                FeatureEvaluationResult result =
+                        configuredStrategy.getResult(
+                                strategy.getParameters(),
+                                enhancedContext,
+                                ConstraintMerger.mergeConstraints(featureRepository, strategy),
+                                strategy.getVariants());
 
                 if (result.isEnabled()) {
-                    Variant variant = result.isEnabled() ? result.getVariant() : null;
+                    Variant variant = result.getVariant();
                     // If strategy variant is null, look for a variant in the featureToggle
-                    if (variant == null && defaultVariant != null) {
-                        variant =
-                            result.isEnabled()
-                                ? VariantUtil.selectVariant(featureToggle, context, defaultVariant)
-                                : defaultVariant;
+                    if (variant == null) {
+                        variant = VariantUtil.selectVariant(featureToggle, context, defaultVariant);
                     }
                     result.setVariant(variant);
                     return result;
                 }
             }
         }
-        return new FeatureEvaluationResult(enabled, defaultVariant);
+
+        return new FeatureEvaluationResult(enabled, enabled?VariantUtil.selectVariant(featureToggle, context, defaultVariant):defaultVariant);
     }
 
     private void checkIfToggleMatchesNamePrefix(String toggleName) {

--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -163,13 +163,12 @@ public class DefaultUnleash implements Unleash {
         FeatureToggle featureToggle = featureRepository.getToggle(toggleName);
 
         UnleashContext enhancedContext = context.applyStaticFields(config);
-        boolean enabled = false;
         if (featureToggle == null) {
-            enabled = fallbackAction.test(toggleName, enhancedContext);
+            return new FeatureEvaluationResult(fallbackAction.test(toggleName, enhancedContext), defaultVariant);
         } else if (!featureToggle.isEnabled()) {
-            enabled = false;
+            return new FeatureEvaluationResult(false, defaultVariant);
         } else if (featureToggle.getStrategies().size() == 0) {
-            enabled = true;
+            return new FeatureEvaluationResult(true, VariantUtil.selectVariant(featureToggle, context, defaultVariant));
         } else {
             for (ActivationStrategy strategy : featureToggle.getStrategies()) {
                 Strategy configuredStrategy = getStrategy(strategy.getName());
@@ -197,9 +196,8 @@ public class DefaultUnleash implements Unleash {
                     return result;
                 }
             }
+            return new FeatureEvaluationResult(false, defaultVariant);
         }
-
-        return new FeatureEvaluationResult(enabled, enabled?VariantUtil.selectVariant(featureToggle, context, defaultVariant):defaultVariant);
     }
 
     private void checkIfToggleMatchesNamePrefix(String toggleName) {

--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -164,11 +164,13 @@ public class DefaultUnleash implements Unleash {
 
         UnleashContext enhancedContext = context.applyStaticFields(config);
         if (featureToggle == null) {
-            return new FeatureEvaluationResult(fallbackAction.test(toggleName, enhancedContext), defaultVariant);
+            return new FeatureEvaluationResult(
+                    fallbackAction.test(toggleName, enhancedContext), defaultVariant);
         } else if (!featureToggle.isEnabled()) {
             return new FeatureEvaluationResult(false, defaultVariant);
         } else if (featureToggle.getStrategies().size() == 0) {
-            return new FeatureEvaluationResult(true, VariantUtil.selectVariant(featureToggle, context, defaultVariant));
+            return new FeatureEvaluationResult(
+                    true, VariantUtil.selectVariant(featureToggle, context, defaultVariant));
         } else {
             for (ActivationStrategy strategy : featureToggle.getStrategies()) {
                 Strategy configuredStrategy = getStrategy(strategy.getName());

--- a/src/main/java/io/getunleash/strategy/Strategy.java
+++ b/src/main/java/io/getunleash/strategy/Strategy.java
@@ -22,8 +22,8 @@ public interface Strategy {
             @Nullable List<VariantDefinition> variants) {
         boolean enabled = isEnabled(parameters, unleashContext, constraints);
         return new FeatureEvaluationResult(
-            enabled,
-            enabled? VariantUtil.selectVariant(parameters, variants, unleashContext) : null);
+                enabled,
+                enabled ? VariantUtil.selectVariant(parameters, variants, unleashContext) : null);
     }
 
     default boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {

--- a/src/main/java/io/getunleash/strategy/Strategy.java
+++ b/src/main/java/io/getunleash/strategy/Strategy.java
@@ -20,9 +20,10 @@ public interface Strategy {
             UnleashContext unleashContext,
             List<Constraint> constraints,
             @Nullable List<VariantDefinition> variants) {
+        boolean enabled = isEnabled(parameters, unleashContext, constraints);
         return new FeatureEvaluationResult(
-                isEnabled(parameters, unleashContext, constraints),
-                VariantUtil.selectVariant(parameters, variants, unleashContext));
+            enabled,
+            enabled? VariantUtil.selectVariant(parameters, variants, unleashContext) : null);
     }
 
     default boolean isEnabled(Map<String, String> parameters, UnleashContext unleashContext) {

--- a/src/test/java/io/getunleash/DefaultUnleashTest.java
+++ b/src/test/java/io/getunleash/DefaultUnleashTest.java
@@ -129,6 +129,7 @@ class DefaultUnleashTest {
     @Test
     public void should_allow_fallback_strategy() {
         Strategy fallback = mock(Strategy.class);
+        when(fallback.getResult(anyMap(), any(), anyList(), anyList())).thenCallRealMethod();
 
         UnleashConfig unleashConfigWithFallback =
                 UnleashConfig.builder()
@@ -152,7 +153,7 @@ class DefaultUnleashTest {
 
         sut.isEnabled("toggle1");
 
-        verify(fallback).isEnabled(any(), any());
+        verify(fallback).isEnabled(any(), any(), anyList());
     }
 
     @Test

--- a/src/test/java/io/getunleash/UnleashTest.java
+++ b/src/test/java/io/getunleash/UnleashTest.java
@@ -163,7 +163,7 @@ public class UnleashTest {
     }
 
     @Test
-    public void should_support_multiple_rollout_strategies() {
+    public void shouldSupportMultipleRolloutStrategies() {
         Map<String, String> rollout100percent = new HashMap<>();
         rollout100percent.put("rollout", "100");
         rollout100percent.put("stickiness", "default");

--- a/src/test/java/io/getunleash/UnleashTest.java
+++ b/src/test/java/io/getunleash/UnleashTest.java
@@ -1,6 +1,7 @@
 package io.getunleash;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -158,6 +159,30 @@ public class UnleashTest {
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
         assertThat(unleash.isEnabled("test")).isTrue();
+    }
+
+    @Test
+    public void should_support_multiple_rollout_strategies() {
+        Map<String, String> rollout100percent = new HashMap<>();
+        rollout100percent.put("rollout", "100");
+        rollout100percent.put("stickiness", "default");
+        rollout100percent.put("groupId", "rollout");
+
+        Constraint user6Constraint = new Constraint("userId", Operator.IN, singletonList("6"));
+        Constraint user9Constraint = new Constraint("userId", Operator.IN, singletonList("9"));
+
+        ActivationStrategy strategy1 = new ActivationStrategy("flexibleRollout", rollout100percent, singletonList(user6Constraint), null, null);
+        ActivationStrategy strategy2 = new ActivationStrategy("flexibleRollout", rollout100percent, singletonList(user9Constraint), null, null);
+
+        FeatureToggle featureToggle =
+            new FeatureToggle("test", true, asList(strategy1, strategy2));
+
+        when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
+
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("1").build())).isFalse();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("6").build())).isTrue();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("7").build())).isFalse();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("9").build())).isTrue();
     }
 
     @Test

--- a/src/test/java/io/getunleash/UnleashTest.java
+++ b/src/test/java/io/getunleash/UnleashTest.java
@@ -172,18 +172,33 @@ public class UnleashTest {
         Constraint user6Constraint = new Constraint("userId", Operator.IN, singletonList("6"));
         Constraint user9Constraint = new Constraint("userId", Operator.IN, singletonList("9"));
 
-        ActivationStrategy strategy1 = new ActivationStrategy("flexibleRollout", rollout100percent, singletonList(user6Constraint), null, null);
-        ActivationStrategy strategy2 = new ActivationStrategy("flexibleRollout", rollout100percent, singletonList(user9Constraint), null, null);
+        ActivationStrategy strategy1 =
+                new ActivationStrategy(
+                        "flexibleRollout",
+                        rollout100percent,
+                        singletonList(user6Constraint),
+                        null,
+                        null);
+        ActivationStrategy strategy2 =
+                new ActivationStrategy(
+                        "flexibleRollout",
+                        rollout100percent,
+                        singletonList(user9Constraint),
+                        null,
+                        null);
 
-        FeatureToggle featureToggle =
-            new FeatureToggle("test", true, asList(strategy1, strategy2));
+        FeatureToggle featureToggle = new FeatureToggle("test", true, asList(strategy1, strategy2));
 
         when(toggleRepository.getToggle("test")).thenReturn(featureToggle);
 
-        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("1").build())).isFalse();
-        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("6").build())).isTrue();
-        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("7").build())).isFalse();
-        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("9").build())).isTrue();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("1").build()))
+                .isFalse();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("6").build()))
+                .isTrue();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("7").build()))
+                .isFalse();
+        assertThat(unleash.isEnabled("test", UnleashContext.builder().userId("9").build()))
+                .isTrue();
     }
 
     @Test

--- a/src/test/java/io/getunleash/UnleashTest.java
+++ b/src/test/java/io/getunleash/UnleashTest.java
@@ -130,6 +130,7 @@ public class UnleashTest {
         // custom strategy
         Strategy customStrategy = mock(Strategy.class);
         when(customStrategy.getName()).thenReturn("custom");
+        when(customStrategy.getResult(anyMap(), any(), anyList(), anyList())).thenCallRealMethod();
 
         // register custom strategy
         UnleashConfig config =
@@ -145,7 +146,7 @@ public class UnleashTest {
 
         unleash.isEnabled("test");
 
-        verify(customStrategy, times(1)).isEnabled(any(), any(UnleashContext.class));
+        verify(customStrategy, times(1)).isEnabled(any(), any(UnleashContext.class), anyList());
     }
 
     @Test


### PR DESCRIPTION
## About the changes
The code selecting an activation strategy was exiting on a first enable match but the strategy being enabled does not mean the feature will be enabled. We need to iterate and evaluate each one of the strategies before returning.

Closes #210
