### PR TITLE
feat: make sure gpg entry expects passphrase in environment variable

### DIFF
--- a/.github/workflows/release_to_central.yml
+++ b/.github/workflows/release_to_central.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Release
         run: mvn -B -DreleaseVersion=${{ inputs.version}} release:prepare release:perform
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ target
 
 .DS_Store
 **/bin/
+.vim/

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,8 @@
 
     <scm>
         <url>https://github.com/Unleash/unleash-client-java</url>
-        <connection>scm:git:git@github.com:Unleash/unleash-client-java.git</connection>
-        <developerConnection>scm:git:git@github.com:Unleash/unleash-client-java.git</developerConnection>
-        <tag>unleash-client-java-8.3.1</tag>
+        <connection>scm:git:https://github.com/Unleash/unleash-client-java.git</connection>
+        <developerConnection>scm:git:https://github.com/Unleash/unleash-client-java.git</developerConnection>
     </scm>
 
     <dependencies>
@@ -464,7 +463,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -473,7 +472,13 @@
                                     <goal>sign</goal>
                                 </goals>
                             </execution>
-                        </executions>
+                          </executions>
+                          <configuration>
+                            <gpgArguments>
+                              <arg>--pinentry-mode</arg>
+                              <arg>loopback</arg>
+                            </gpgArguments>
+                          </configuration>
                     </plugin>
                 </plugins>
 


### PR DESCRIPTION
As we saw when we tried to release 8.3.1, we had an `inappropriate ioctl for device`. This PR adds a pinentry rule to loopback, so that we can pass in the passphrase as environment variable. In addition it switches the scm URLs to point to https URLs so our maven process is able to update the github repository with tags. 

Tested in https://github.com/chriswk/javarelease, we know the publishing to maven central repo works, but we need to know that the git tagging works as well.