### PR TITLE
chore: allow to fail if unavailable

### DIFF
--- a/src/main/java/io/getunleash/repository/FeatureRepository.java
+++ b/src/main/java/io/getunleash/repository/FeatureRepository.java
@@ -110,10 +110,6 @@ public class FeatureRepository implements IFeatureRepository {
         }
     }
 
-    private Integer calculateMaxSkips(int fetchTogglesInterval) {
-        return Integer.max(20, 300 / Integer.max(fetchTogglesInterval, 1));
-    }
-
     private Runnable updateFeatures(final Consumer<UnleashException> handler) {
         return () -> {
             if (throttler.performAction()) {

--- a/src/main/java/io/getunleash/repository/FeatureRepository.java
+++ b/src/main/java/io/getunleash/repository/FeatureRepository.java
@@ -95,7 +95,9 @@ public class FeatureRepository implements IFeatureRepository {
         }
 
         if (unleashConfig.isSynchronousFetchOnInitialisation()) {
-            updateFeatures(null).run();
+            updateFeatures(e -> {
+                throw e;
+            }).run();
         }
 
         if (!unleashConfig.isDisablePolling()) {
@@ -112,7 +114,7 @@ public class FeatureRepository implements IFeatureRepository {
         return Integer.max(20, 300 / Integer.max(fetchTogglesInterval, 1));
     }
 
-    private Runnable updateFeatures(@Nullable final Consumer<UnleashException> handler) {
+    private Runnable updateFeatures(final Consumer<UnleashException> handler) {
         return () -> {
             if (throttler.performAction()) {
                 try {
@@ -129,7 +131,12 @@ public class FeatureRepository implements IFeatureRepository {
 
                         featureBackupHandler.write(featureCollection);
                     } else if (response.getStatus() == ClientFeaturesResponse.Status.UNAVAILABLE) {
-                        throttler.handleHttpErrorCodes(response.getHttpStatusCode());
+                        if (!ready && unleashConfig.isSynchronousFetchOnInitialisation()) {
+                            throw new UnleashException(String.format("Could not initialize Unleash, got response code %d", response.getHttpStatusCode()), null);
+                        }
+                        if (ready) {
+                            throttler.handleHttpErrorCodes(response.getHttpStatusCode());
+                        }
                         return;
                     }
                     throttler.decrementFailureCountAndResetSkips();
@@ -138,11 +145,7 @@ public class FeatureRepository implements IFeatureRepository {
                         ready = true;
                     }
                 } catch (UnleashException e) {
-                    if (handler != null) {
-                        handler.accept(e);
-                    } else {
-                        throw e;
-                    }
+                    handler.accept(e);
                 }
             } else {
                 throttler.skipped(); // We didn't do anything this iteration, just reduce the count

--- a/src/test/java/io/getunleash/repository/FeatureRepositoryTest.java
+++ b/src/test/java/io/getunleash/repository/FeatureRepositoryTest.java
@@ -325,22 +325,20 @@ public class FeatureRepositoryTest {
                         bootstrapHandler);
 
         runner.assertThatFetchesAndReceives(UNAVAILABLE, 429);
+        // client is not ready don't count errors or skips
         assertThat(featureRepository.getSkips()).isEqualTo(0);
         assertThat(featureRepository.getFailures()).isEqualTo(0);
 
         runner.assertThatFetchesAndReceives(UNAVAILABLE, 429);
-        verify(fetcher, times(2)).fetchFeatures();
         // client is not ready don't count errors or skips
         assertThat(featureRepository.getSkips()).isEqualTo(0);
         assertThat(featureRepository.getFailures()).isEqualTo(0);
 
         // this changes the client to ready
         runner.assertThatFetchesAndReceives(CHANGED, 200);
-        verify(fetcher, times(3)).fetchFeatures();
         assertThat(featureRepository.getSkips()).isEqualTo(0);
 
         runner.assertThatFetchesAndReceives(UNAVAILABLE, 429);
-        verify(fetcher, times(4)).fetchFeatures();
         assertThat(featureRepository.getSkips()).isEqualTo(1);
         assertThat(featureRepository.getFailures()).isEqualTo(1);
 


### PR DESCRIPTION
## About the changes
On synchronous initialization, we were not failing in case of an invalid response code but still marking the client as ready. With this change, we're making sure we have a valid features collection before marking the client as ready and we're not going to throttle in case of asynchronous initialization.