### PR TITLE
fix: check that contextValue starts with

### DIFF
--- a/src/main/java/io/getunleash/strategy/constraints/StringConstraintOperator.java
+++ b/src/main/java/io/getunleash/strategy/constraints/StringConstraintOperator.java
@@ -58,17 +58,17 @@ public class StringConstraintOperator implements ConstraintOperator {
             List<String> values, Optional<String> contextValue, boolean caseInsensitive) {
         return contextValue
                 .map(
-                        c ->
+                    actualContextValue ->
                                 values.stream()
                                         .anyMatch(
-                                                v -> {
+                                            value -> {
                                                     if (caseInsensitive) {
-                                                        return v.toLowerCase(comparisonLocale)
+                                                        return actualContextValue.toLowerCase(comparisonLocale)
                                                                 .startsWith(
-                                                                        c.toLowerCase(
+                                                                        value.toLowerCase(
                                                                                 comparisonLocale));
                                                     } else {
-                                                        return c.startsWith(v);
+                                                        return actualContextValue.startsWith(value);
                                                     }
                                                 }))
                 .orElse(false);

--- a/src/test/java/io/getunleash/strategy/constraints/StringConstraintOperatorTest.java
+++ b/src/test/java/io/getunleash/strategy/constraints/StringConstraintOperatorTest.java
@@ -211,4 +211,25 @@ class StringConstraintOperatorTest {
                         .build();
         assertThat(strategy.isEnabled(parameters, ctx, constraintList)).isFalse();
     }
+
+    @Test
+    public void startsWithShouldMatchCorrectlyWhenCaseSensitive() {
+        Strategy strategy = new DefaultStrategy();
+        List<Constraint> constraintList = Collections.singletonList(new Constraint("email", Operator.STR_STARTS_WITH, Collections.singletonList("testuser"), false, false));
+        Map<String, String> parameters = new HashMap<>();
+        UnleashContext ctx = UnleashContext.builder().environment("dev").addProperty("email", "TESTUSER@getunleash.io").build();
+        assertThat(strategy.isEnabled(parameters, ctx, constraintList)).isFalse();
+        UnleashContext ctx2 = UnleashContext.builder().environment("dev").addProperty("email", "testuser@getunleash.io").build();
+        assertThat(strategy.isEnabled(parameters, ctx2, constraintList)).isTrue();
+    }
+    @Test
+    public void startsWithShouldMatchCorrectlyWhenCaseInsensitive() {
+        Strategy strategy = new DefaultStrategy();
+        List<Constraint> constraintList = Collections.singletonList(new Constraint("email", Operator.STR_STARTS_WITH, Collections.singletonList("testuser"), false, true));
+        Map<String, String> parameters = new HashMap<>();
+        UnleashContext ctx = UnleashContext.builder().environment("dev").addProperty("email", "TESTUSER@getunleash.io").build();
+        assertThat(strategy.isEnabled(parameters, ctx, constraintList)).isTrue();
+        UnleashContext ctx2 = UnleashContext.builder().environment("dev").addProperty("email", "testuser@getunleash.io").build();
+        assertThat(strategy.isEnabled(parameters, ctx2, constraintList)).isTrue();
+    }
 }


### PR DESCRIPTION
There had been an inversion of variable usage for one of our cases in the matcher. This PR makes sure to compare contextValue to see if it starts with the requested value in the constraint, instead of the other way around.

fixes #238

