### PR TITLE
chore: Use client spec 5.1.5 instead of 5.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <version.junit5>5.10.0</version.junit5>
         <version.okhttp>4.10.0</version.okhttp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.unleash.specification>5.0.2</version.unleash.specification>
+        <version.unleash.specification>5.1.5</version.unleash.specification>
         <arguments />
         <version.jackson>2.14.3</version.jackson>
     </properties>

--- a/src/main/java/io/getunleash/strategy/FlexibleRolloutStrategy.java
+++ b/src/main/java/io/getunleash/strategy/FlexibleRolloutStrategy.java
@@ -59,8 +59,4 @@ public class FlexibleRolloutStrategy implements Strategy {
                 .map(norm -> percentage > 0 && norm <= percentage)
                 .orElse(false);
     }
-
-    private String getStickiness(Map<String, String> parameters) {
-        return parameters.getOrDefault("stickiness", "default");
-    }
 }

--- a/src/main/java/io/getunleash/strategy/Strategy.java
+++ b/src/main/java/io/getunleash/strategy/Strategy.java
@@ -21,9 +21,13 @@ public interface Strategy {
             List<Constraint> constraints,
             @Nullable List<VariantDefinition> variants) {
         boolean enabled = isEnabled(parameters, unleashContext, constraints);
+        String strategyStickiness = getStickiness(parameters);
         return new FeatureEvaluationResult(
                 enabled,
-                enabled ? VariantUtil.selectVariant(parameters, variants, unleashContext) : null);
+                enabled
+                        ? VariantUtil.selectVariant(
+                                parameters, variants, unleashContext, strategyStickiness)
+                        : null);
     }
 
     /**
@@ -60,5 +64,12 @@ public interface Strategy {
             List<Constraint> constraints) {
         return ConstraintUtil.validate(constraints, unleashContext)
                 && isEnabled(parameters, unleashContext);
+    }
+
+    default String getStickiness(@Nullable Map<String, String> parameters) {
+        if (parameters != null) {
+            return parameters.getOrDefault("stickiness", "default");
+        }
+        return null;
     }
 }

--- a/src/test/java/io/getunleash/strategy/StrategyVariantTest.java
+++ b/src/test/java/io/getunleash/strategy/StrategyVariantTest.java
@@ -1,0 +1,128 @@
+package io.getunleash.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.getunleash.FeatureEvaluationResult;
+import io.getunleash.UnleashContext;
+import io.getunleash.Variant;
+import io.getunleash.variant.Payload;
+import io.getunleash.variant.VariantDefinition;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+public class StrategyVariantTest {
+
+    @Test
+    public void should_inherit_stickiness_from_the_strategy_first_variant() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("rollout", "100");
+        params.put("stickiness", "clientId");
+        params.put("groupId", "a");
+        FlexibleRolloutStrategy strategy = new FlexibleRolloutStrategy();
+        VariantDefinition varA =
+                new VariantDefinition(
+                        "variantNameA",
+                        1,
+                        new Payload("string", "variantValueA"),
+                        Collections.emptyList());
+        VariantDefinition varB =
+                new VariantDefinition(
+                        "variantNameB",
+                        1,
+                        new Payload("string", "variantValueB"),
+                        Collections.emptyList());
+
+        UnleashContext context = UnleashContext.builder().addProperty("clientId", "1").build();
+        FeatureEvaluationResult result =
+                strategy.getResult(
+                        params, context, Collections.emptyList(), Arrays.asList(varA, varB));
+        Variant selectedVariant = result.getVariant();
+        assert selectedVariant != null;
+        assertThat(selectedVariant.getName()).isEqualTo("variantNameA");
+    }
+
+    @Test
+    public void should_inherit_stickiness_from_the_strategy_second_variant() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("rollout", "100");
+        params.put("stickiness", "clientId");
+        params.put("groupId", "a");
+        FlexibleRolloutStrategy strategy = new FlexibleRolloutStrategy();
+        VariantDefinition varA =
+                new VariantDefinition(
+                        "variantNameA",
+                        1,
+                        new Payload("string", "variantValueA"),
+                        Collections.emptyList());
+        VariantDefinition varB =
+                new VariantDefinition(
+                        "variantNameB",
+                        1,
+                        new Payload("string", "variantValueB"),
+                        Collections.emptyList());
+
+        UnleashContext context = UnleashContext.builder().addProperty("clientId", "2").build();
+        FeatureEvaluationResult result =
+                strategy.getResult(
+                        params, context, Collections.emptyList(), Arrays.asList(varA, varB));
+        Variant selectedVariant = result.getVariant();
+        assert selectedVariant != null;
+        assertThat(selectedVariant.getName()).isEqualTo("variantNameB");
+    }
+
+    @Test
+    public void multiple_variants_should_choose_first_variant() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("rollout", "100");
+        params.put("groupId", "a");
+        params.put("stickiness", "default");
+        FlexibleRolloutStrategy strategy = new FlexibleRolloutStrategy();
+        VariantDefinition varA =
+                new VariantDefinition(
+                        "variantNameA",
+                        1,
+                        new Payload("string", "variantValueA"),
+                        Collections.emptyList());
+        VariantDefinition varB =
+                new VariantDefinition(
+                        "variantNameB",
+                        1,
+                        new Payload("string", "variantValueB"),
+                        Collections.emptyList());
+        UnleashContext context = UnleashContext.builder().userId("5").build();
+        FeatureEvaluationResult result =
+                strategy.getResult(
+                        params, context, Collections.emptyList(), Arrays.asList(varA, varB));
+        Variant selectedVariant = result.getVariant();
+        assertThat(selectedVariant.getName()).isEqualTo("variantNameA");
+    }
+
+    @Test
+    public void multiple_variants_should_choose_second_variant() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("rollout", "100");
+        params.put("groupId", "a");
+        params.put("stickiness", "default");
+        FlexibleRolloutStrategy strategy = new FlexibleRolloutStrategy();
+        VariantDefinition varA =
+                new VariantDefinition(
+                        "variantNameA",
+                        1,
+                        new Payload("string", "variantValueA"),
+                        Collections.emptyList());
+        VariantDefinition varB =
+                new VariantDefinition(
+                        "variantNameB",
+                        1,
+                        new Payload("string", "variantValueB"),
+                        Collections.emptyList());
+        UnleashContext context = UnleashContext.builder().userId("0").build();
+        FeatureEvaluationResult result =
+                strategy.getResult(
+                        params, context, Collections.emptyList(), Arrays.asList(varA, varB));
+        Variant selectedVariant = result.getVariant();
+        assertThat(selectedVariant.getName()).isEqualTo("variantNameB");
+    }
+}


### PR DESCRIPTION
To make sure the SDK is up to date with our tests. This bumps to the newest client-spec.