### PR TITLE
fix: enableAll and disableAll overrides fallback

### DIFF
--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -38,7 +38,7 @@ public class FakeUnleash implements Unleash {
     @Override
     public boolean isEnabled(
             String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
-        if (!features.containsKey(toggleName)) {
+        if ((!enableAll && !disableAll || excludedFeatures.containsKey(toggleName)) && !features.containsKey(toggleName)) {
             return fallbackAction.test(toggleName, UnleashContext.builder().build());
         }
         return isEnabled(toggleName);

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -38,7 +38,8 @@ public class FakeUnleash implements Unleash {
     @Override
     public boolean isEnabled(
             String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
-        if ((!enableAll && !disableAll || excludedFeatures.containsKey(toggleName)) && !features.containsKey(toggleName)) {
+        if ((!enableAll && !disableAll || excludedFeatures.containsKey(toggleName))
+                && !features.containsKey(toggleName)) {
             return fallbackAction.test(toggleName, UnleashContext.builder().build());
         }
         return isEnabled(toggleName);

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -181,23 +181,30 @@ public class FakeUnleashTest {
     }
 
     @Test
-    public void if_all_is_enabled_should_return_true_even_if_feature_does_not_exist_and_fallback_returns_false() {
+    public void
+            if_all_is_enabled_should_return_true_even_if_feature_does_not_exist_and_fallback_returns_false() {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.enableAll();
-        assertThat(fakeUnleash.isEnabled("my.non.existing.feature", (name, context) -> false)).isTrue();
+        assertThat(fakeUnleash.isEnabled("my.non.existing.feature", (name, context) -> false))
+                .isTrue();
     }
 
     @Test
-    public void if_all_is_disabled_should_return_false_even_if_feature_does_not_exist_and_fallback_returns_true() {
+    public void
+            if_all_is_disabled_should_return_false_even_if_feature_does_not_exist_and_fallback_returns_true() {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.disableAll();
-        assertThat(fakeUnleash.isEnabled("my.non.existing.feature", (name, context) -> true)).isFalse();
+        assertThat(fakeUnleash.isEnabled("my.non.existing.feature", (name, context) -> true))
+                .isFalse();
     }
 
     @Test
     public void all_enabled_and_exclusion_toggle_returns_expected_result() {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.enableAllExcept("my.feature.that.should.be.disabled");
-        assertThat(fakeUnleash.isEnabled("my.feature.that.should.be.disabled", (name, context) -> false)).isFalse();
+        assertThat(
+                        fakeUnleash.isEnabled(
+                                "my.feature.that.should.be.disabled", (name, context) -> false))
+                .isFalse();
     }
 }

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -179,4 +179,25 @@ public class FakeUnleashTest {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.more().countVariant("toggleName", "variantName");
     }
+
+    @Test
+    public void if_all_is_enabled_should_return_true_even_if_feature_does_not_exist_and_fallback_returns_false() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.enableAll();
+        assertThat(fakeUnleash.isEnabled("my.non.existing.feature", (name, context) -> false)).isTrue();
+    }
+
+    @Test
+    public void if_all_is_disabled_should_return_false_even_if_feature_does_not_exist_and_fallback_returns_true() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.disableAll();
+        assertThat(fakeUnleash.isEnabled("my.non.existing.feature", (name, context) -> true)).isFalse();
+    }
+
+    @Test
+    public void all_enabled_and_exclusion_toggle_returns_expected_result() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.enableAllExcept("my.feature.that.should.be.disabled");
+        assertThat(fakeUnleash.isEnabled("my.feature.that.should.be.disabled", (name, context) -> false)).isFalse();
+    }
 }


### PR DESCRIPTION
As discussed in #239 - When all is enabled, we had a bit of a surprising
behaviour where we'd fallback to fallback action for
`isEnabled(featureName, fallback)` even if all was enabled and feature
did not exist.

This PR fixes that, and adds tests to confirm this behaviour is intentional.

closes: #239