### PR TITLE
UnleashContext.Builder Convenience

### DIFF
--- a/src/main/java/io/getunleash/UnleashContext.java
+++ b/src/main/java/io/getunleash/UnleashContext.java
@@ -129,7 +129,7 @@ public class UnleashContext {
             context.sessionId.ifPresent(val -> this.sessionId = val);
             context.remoteAddress.ifPresent(val -> this.remoteAddress = val);
             context.currentTime.ifPresent(val -> this.currentTime = val);
-            context.properties.forEach(this.properties::put);
+            this.properties.putAll(context.properties);
         }
 
         public Builder appName(String appName) {
@@ -173,7 +173,26 @@ public class UnleashContext {
         }
 
         public Builder addProperty(String name, String value) {
-            properties.put(name, value);
+            switch (name) {
+                case "environment":
+                    this.environment = value;
+                    break;
+                case "appName":
+                    this.appName = value;
+                    break;
+                case "userId":
+                    this.userId = value;
+                    break;
+                case "sessionId":
+                    this.sessionId = value;
+                    break;
+                case "remoteAddress":
+                    this.remoteAddress = value;
+                    break;
+                default:
+                    this.properties.put(name, value);
+            }
+
             return this;
         }
 

--- a/src/test/java/io/getunleash/UnleashContextTest.java
+++ b/src/test/java/io/getunleash/UnleashContextTest.java
@@ -1,9 +1,11 @@
 package io.getunleash;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.getunleash.util.UnleashConfig;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
 
 public class UnleashContextTest {
 
@@ -39,7 +41,7 @@ public class UnleashContextTest {
         assertThat(context.getRemoteAddress()).hasValue("127.0.0.1");
         assertThat(context.getEnvironment()).hasValue("prod");
         assertThat(context.getAppName()).hasValue("myapp");
-        assertThat(context.getProperties().get("test")).isEqualTo("me");
+        assertThat(context.getProperties()).containsExactly(entry("test", "me"));
     }
 
     @Test
@@ -70,7 +72,7 @@ public class UnleashContextTest {
     }
 
     @Test
-    public void should_not_ovveride_static_context_fields() {
+    public void should_not_override_static_context_fields() {
         UnleashContext context =
                 UnleashContext.builder()
                         .userId("test@mail.com")
@@ -96,4 +98,36 @@ public class UnleashContextTest {
         assertThat(enhanced.getEnvironment()).hasValue("env");
         assertThat(enhanced.getAppName()).hasValue("myApp");
     }
+
+    @Nested
+    class BuilderTest {
+
+        @Test
+        void should_set_special_properties() {
+            final UnleashContext context = UnleashContext.builder()
+                .addProperty("userId", "test@mail.com")
+                .addProperty("sessionId", "123")
+                .addProperty("remoteAddress", "127.0.0.1")
+                .addProperty("environment", "env")
+                .addProperty("appName", "myApp")
+                .build();
+
+            assertThat(context.getUserId()).contains("test@mail.com");
+            assertThat(context.getSessionId()).contains("123");
+            assertThat(context.getRemoteAddress()).contains("127.0.0.1");
+            assertThat(context.getEnvironment()).contains("env");
+            assertThat(context.getAppName()).contains("myApp");
+        }
+
+        @Test
+        void should_set_non_special_properties() {
+            final UnleashContext context = UnleashContext.builder()
+                .addProperty("foo", "bar")
+                .build();
+
+            assertThat(context.getProperties()).containsExactly(entry("foo", "bar"));
+        }
+
+    }
+
 }


### PR DESCRIPTION
- made builder populate special properties by name

<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
Making the io.getunleash.UnleashContext.Builder populate special properties for convenience. 
Sometimes users may specify a property by name and not by method. Currently this property will not be picked up.
This PR addresses this and picks up the special properties for the convenience of the user.