### PR TITLE
chore/os-classifiers-for-build

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         version: [11, 17]
-        os: ["ubuntu"]
+        os: ["windows", "ubuntu"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -6,8 +6,13 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        version: [11, 17]
+        version: [8, 11, 17]
         os: ["ubuntu", "windows", "macos"]
+        exclude:
+        - version: 8
+          os: macos
+        - version: 8
+          os: windows
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -3,10 +3,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        version: [ 8, 11, 17 ]
+        version: [8, 11, 17]
+        os: ["windows", "macos", "ubuntu"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        version: [8, 11, 17]
+        version: [11, 17]
         os: ["windows", "macos", "ubuntu"]
     steps:
       - name: Checkout

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         version: [11, 17]
-        os: ["windows", "macos", "ubuntu"]
+        os: ["ubuntu"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         version: [11, 17]
-        os: ["windows", "ubuntu"]
+        os: ["ubuntu"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         version: [11, 17]
-        os: ["ubuntu"]
+        os: ["ubuntu", "windows", "macos"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>io.getunleash</groupId>
             <artifactId>yggdrasil-engine</artifactId>
-            <version>0.1.0-alpha.10</version>
+            <version>0.1.0-alpha.11</version>
             <classifier>${os.detected.classifier}</classifier>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <version.junit5>5.10.3</version.junit5>
         <version.okhttp>4.12.0</version.okhttp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.unleash.specification>5.1.9</version.unleash.specification>
+        <version.unleash.specification>5.1.8</version.unleash.specification>
         <arguments />
         <version.jackson>2.17.2</version.jackson>
         <version.logback>1.3.14</version.logback>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>io.getunleash</groupId>
             <artifactId>yggdrasil-engine</artifactId>
-            <version>0.1.0-alpha.11</version>
+            <version>0.1.0-alpha.12</version>
             <classifier>${os.detected.classifier}</classifier>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -475,8 +475,8 @@
             <id>linux-x86_64</id>
             <activation>
                 <os>
-                    <!-- <name>linux</name> -->
-                    <arch>x86_64</arch>
+                    <name>Linux</name>
+                    <arch>amd64</arch>
                 </os>
             </activation>
             <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
             <activation>
                 <os>
                     <name>Windows</name>
-                    <arch>amd64</arch>
+                    <arch>x86_64</arch>
                 </os>
             </activation>
             <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -488,12 +488,12 @@
                 </dependency>
             </dependencies>
         </profile>
-        <!-- <profile>
+        <profile>
             <id>windows-x86_64</id>
             <activation>
                 <os>
                     <name>Windows</name>
-                    <arch>x86_64</arch>
+                    <arch>amd64</arch>
                 </os>
             </activation>
             <dependencies>
@@ -505,7 +505,7 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
+        <!-- <profile>
             <id>macos-x86_64</id>
             <activation>
                 <os>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.getunleash</groupId>
+            <artifactId>yggdrasil-engine</artifactId>
+            <version>0.1.0-alpha.10</version>
+            <classifier>${os.detected.classifier}</classifier>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${version.gson}</version>
@@ -156,6 +162,13 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
@@ -471,91 +484,6 @@
 
             </build>
         </profile>
-        <profile>
-            <id>linux-x86_64</id>
-            <activation>
-                <os>
-                    <name>Linux</name>
-                    <arch>amd64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.getunleash</groupId>
-                    <artifactId>yggdrasil-engine</artifactId>
-                    <version>0.1.0-alpha.9</version>
-                    <classifier>x86_64-linux</classifier>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>windows-x86_64</id>
-            <activation>
-                <os>
-                    <name>Windows</name>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.getunleash</groupId>
-                    <artifactId>yggdrasil-engine</artifactId>
-                    <version>0.1.0-alpha.9</version>
-                    <classifier>windows-x86_64</classifier>
-                </dependency>
-            </dependencies>
-        </profile>
-        <!-- <profile>
-            <id>macos-x86_64</id>
-            <activation>
-                <os>
-                    <name>Mac OS X</name>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.getunleash</groupId>
-                    <artifactId>yggdrasil-engine</artifactId>
-                    <version>0.1.0-alpha.9</version>
-                    <classifier>x86_64-macos</classifier>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>macos-aarch64</id>
-            <activation>
-                <os>
-                    <name>Mac OS X</name>
-                    <arch>aarch64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.getunleash</groupId>
-                    <artifactId>yggdrasil-engine</artifactId>
-                    <version>0.1.0-alpha.9</version>
-                    <classifier>aarch64-macos</classifier>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>mac-x86_64</id>
-            <activation>
-                <os>
-                    <name>Windows</name>
-                    <arch>x86_64</arch>
-                </os>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>io.getunleash</groupId>
-                    <artifactId>yggdrasil-engine</artifactId>
-                    <version>0.1.0-alpha.9</version>
-                    <classifier>windows-x86_64</classifier>
-                </dependency>
-            </dependencies>
-        </profile> -->
     </profiles>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <version.junit5>5.10.3</version.junit5>
         <version.okhttp>4.12.0</version.okhttp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.unleash.specification>5.1.8</version.unleash.specification>
+        <version.unleash.specification>5.1.7</version.unleash.specification>
         <arguments />
         <version.jackson>2.17.2</version.jackson>
         <version.logback>1.3.14</version.logback>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
             <id>linux-x86_64</id>
             <activation>
                 <os>
-                    <name>Linux</name>
+                    <name>linux</name>
                     <arch>x86_64</arch>
                 </os>
             </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
             <id>linux-x86_64</id>
             <activation>
                 <os>
-                    <name>linux</name>
+                    <!-- <name>linux</name> -->
                     <arch>x86_64</arch>
                 </os>
             </activation>
@@ -488,7 +488,7 @@
                 </dependency>
             </dependencies>
         </profile>
-        <profile>
+        <!-- <profile>
             <id>windows-x86_64</id>
             <activation>
                 <os>
@@ -555,7 +555,7 @@
                     <classifier>windows-x86_64</classifier>
                 </dependency>
             </dependencies>
-        </profile>
+        </profile> -->
     </profiles>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.getunleash</groupId>
-            <artifactId>yggdrasil-engine</artifactId>
-            <version>0.1.0-alpha.9</version>
-            <classifier>x86_64-linux</classifier>
-        </dependency>
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${version.gson}</version>
@@ -476,6 +470,91 @@
                 </plugins>
 
             </build>
+        </profile>
+        <profile>
+            <id>linux-x86_64</id>
+            <activation>
+                <os>
+                    <name>Linux</name>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.getunleash</groupId>
+                    <artifactId>yggdrasil-engine</artifactId>
+                    <version>0.1.0-alpha.9</version>
+                    <classifier>x86_64-linux</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>windows-x86_64</id>
+            <activation>
+                <os>
+                    <name>Windows</name>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.getunleash</groupId>
+                    <artifactId>yggdrasil-engine</artifactId>
+                    <version>0.1.0-alpha.9</version>
+                    <classifier>windows-x86_64</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>macos-x86_64</id>
+            <activation>
+                <os>
+                    <name>Mac OS X</name>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.getunleash</groupId>
+                    <artifactId>yggdrasil-engine</artifactId>
+                    <version>0.1.0-alpha.9</version>
+                    <classifier>x86_64-macos</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>macos-aarch64</id>
+            <activation>
+                <os>
+                    <name>Mac OS X</name>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.getunleash</groupId>
+                    <artifactId>yggdrasil-engine</artifactId>
+                    <version>0.1.0-alpha.9</version>
+                    <classifier>aarch64-macos</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>mac-x86_64</id>
+            <activation>
+                <os>
+                    <name>Windows</name>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.getunleash</groupId>
+                    <artifactId>yggdrasil-engine</artifactId>
+                    <version>0.1.0-alpha.9</version>
+                    <classifier>windows-x86_64</classifier>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
     <repositories>


### PR DESCRIPTION
Adds Maven classifiers to the build system so that maven automatically picks up the correct os/arch at build time and installs the correct version of Yggdrasil that contains that platform's binary