### PR TITLE
chore: update yggdrasil to handle latest spec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <version.junit5>5.10.3</version.junit5>
         <version.okhttp>4.12.0</version.okhttp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.unleash.specification>5.1.7</version.unleash.specification>
+        <version.unleash.specification>5.1.9</version.unleash.specification>
         <arguments />
         <version.jackson>2.17.2</version.jackson>
         <version.logback>1.3.14</version.logback>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>io.getunleash</groupId>
             <artifactId>yggdrasil-engine</artifactId>
-            <version>0.1.0-alpha.12</version>
+            <version>0.1.0-alpha.14</version>
             <classifier>${os.detected.classifier}</classifier>
         </dependency>
         <dependency>

--- a/src/main/java/io/getunleash/DefaultUnleash.java
+++ b/src/main/java/io/getunleash/DefaultUnleash.java
@@ -106,7 +106,7 @@ public class DefaultUnleash implements Unleash {
                     try {
                         this.unleashEngine.takeState(
                                 JsonFeatureParser.toJsonString(featureCollection));
-                    } catch (YggdrasilInvalidInputException e) {
+                    } catch (YggdrasilInvalidInputException | YggdrasilError e) {
                         LOGGER.error("Unable to update features", e);
                     }
                 });

--- a/src/main/java/io/getunleash/metric/ClientMetrics.java
+++ b/src/main/java/io/getunleash/metric/ClientMetrics.java
@@ -1,6 +1,7 @@
 package io.getunleash.metric;
 
 import io.getunleash.engine.MetricsBucket;
+import io.getunleash.engine.UnleashEngine;
 import io.getunleash.event.UnleashEvent;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.lang.Nullable;
@@ -25,7 +26,7 @@ public class ClientMetrics implements UnleashEvent {
         this.specVersion = config.getClientSpecificationVersion();
         this.platformName = System.getProperty("java.vm.name");
         this.platformVersion = System.getProperty("java.version");
-        this.yggdrasilVersion = null;
+        this.yggdrasilVersion = UnleashEngine.getCoreVersion();
     }
 
     public String getAppName() {

--- a/src/main/java/io/getunleash/metric/ClientRegistration.java
+++ b/src/main/java/io/getunleash/metric/ClientRegistration.java
@@ -1,5 +1,6 @@
 package io.getunleash.metric;
 
+import io.getunleash.engine.UnleashEngine;
 import io.getunleash.event.UnleashEvent;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.lang.Nullable;
@@ -31,7 +32,7 @@ public class ClientRegistration implements UnleashEvent {
         this.specVersion = config.getClientSpecificationVersion();
         this.platformName = System.getProperty("java.vm.name");
         this.platformVersion = System.getProperty("java.version");
-        this.yggdrasilVersion = null;
+        this.yggdrasilVersion = UnleashEngine.getCoreVersion();
     }
 
     public String getAppName() {

--- a/src/test/java/io/getunleash/DefaultUnleashTest.java
+++ b/src/test/java/io/getunleash/DefaultUnleashTest.java
@@ -310,6 +310,7 @@ class DefaultUnleashTest {
                         .build();
 
         Unleash unleash = new DefaultUnleash(config);
+        Thread.sleep(1);
         verify(fetcher, times(1)).fetchFeatures();
         Thread.sleep(1200);
         verify(fetcher, times(2)).fetchFeatures();

--- a/src/test/java/io/getunleash/metric/UnleashMetricServiceImplTest.java
+++ b/src/test/java/io/getunleash/metric/UnleashMetricServiceImplTest.java
@@ -448,7 +448,7 @@ public class UnleashMetricServiceImplTest {
         verify(sender, times(1)).sendMetrics(metricsSent.capture());
         ClientMetrics metrics = metricsSent.getValue();
         assertThat(metrics.getSpecVersion()).isNotEmpty();
-        assertThat(metrics.getYggdrasilVersion()).isNull();
+        assertThat(metrics.getYggdrasilVersion()).isNotEmpty();
         assertThat(metrics.getPlatformName()).isNotEmpty();
         assertThat(metrics.getPlatformVersion()).isNotEmpty();
     }
@@ -467,6 +467,6 @@ public class UnleashMetricServiceImplTest {
         assertThat(reg.getPlatformName()).isNotEmpty();
         assertThat(reg.getPlatformVersion()).isNotEmpty();
         assertThat(reg.getSpecVersion()).isEqualTo(config.getClientSpecificationVersion());
-        assertThat(reg.getYggdrasilVersion()).isNull();
+        assertThat(reg.getYggdrasilVersion()).isNotEmpty();
     }
 }

--- a/src/test/java/io/getunleash/repository/UnleashEngineStateHandler.java
+++ b/src/test/java/io/getunleash/repository/UnleashEngineStateHandler.java
@@ -55,7 +55,7 @@ public class UnleashEngineStateHandler {
     public void setState(String raw) {
         try {
             this.unleashEngine.takeState(raw);
-        } catch (YggdrasilInvalidInputException e) {
+        } catch (YggdrasilInvalidInputException | YggdrasilError e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
Bumps Yggdrasil to expose the core version and handle UTF-8 characters

"Fixes" a timing issue on Windows in the tests. How did we not notice that before? Well we've never run these tests on a Windows runner