### PR TITLE
fix: revert previous version scheme

### DIFF
--- a/src/main/java/io/getunleash/util/UnleashConfig.java
+++ b/src/main/java/io/getunleash/util/UnleashConfig.java
@@ -736,7 +736,7 @@ public class UnleashConfig {
             String version =
                     Optional.ofNullable(getClass().getPackage().getImplementationVersion())
                             .orElse("development");
-            return "unleash-java@" + version;
+            return "unleash-client-java:" + version;
         }
     }
 }

--- a/src/test/java/io/getunleash/util/UnleashConfigTest.java
+++ b/src/test/java/io/getunleash/util/UnleashConfigTest.java
@@ -113,7 +113,7 @@ public class UnleashConfigTest {
         UnleashConfig config =
                 UnleashConfig.builder().appName("my-app").unleashAPI("http://unleash.org").build();
 
-        assertThat(config.getSdkVersion()).isEqualTo("unleash-java@development");
+        assertThat(config.getSdkVersion()).isEqualTo("unleash-client-java:development");
     }
 
     @Test
@@ -160,7 +160,7 @@ public class UnleashConfigTest {
         assertThat(connection.getRequestProperty(UNLEASH_INSTANCE_ID_HEADER)).isEqualTo(instanceId);
         assertThat(connection.getRequestProperty(UNLEASH_CONNECTION_ID_HEADER)).hasSize(36);
         assertThat(connection.getRequestProperty(UNLEASH_SDK_HEADER))
-                .isEqualTo("unleash-java@development");
+                .isEqualTo("unleash-client-java:development");
         assertThat(connection.getRequestProperty("User-Agent")).isEqualTo(appName);
     }
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes

After some digging I realized that same version setting we use for the new `x-unleash-sdk` is also used for the registration calls. I'm reverting back the `unleash-client-java:version` convention instead of the new `unleash-java@version`. We use the colon convention a lot in the backend code. Since the new header is not used yet it can be synced with the old convention for now.

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
