### PR TITLE
fix: broken togglebootstraphandler link in javadoc

### DIFF
--- a/src/main/java/io/getunleash/repository/ToggleBootstrapProvider.java
+++ b/src/main/java/io/getunleash/repository/ToggleBootstrapProvider.java
@@ -8,7 +8,7 @@ public interface ToggleBootstrapProvider {
      * src/test/resources/features-v1.json or src/test/resources/unleash-repo-v1.json for example
      * Example in {@link ToggleBootstrapFileProvider}
      *
-     * @return JSON string that can be sent to {@link ToggleBootstrapHandler#parse(String)}
+     * @return JSON string representing a response from /api/client/features
      */
     Optional<String> read();
 }


### PR DESCRIPTION
Removes a reference to a class that no longer exists