### PR TITLE
chore: bump yggdrasil to a version that doesn't need os resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,7 @@
         <dependency>
             <groupId>io.getunleash</groupId>
             <artifactId>yggdrasil-engine</artifactId>
-            <version>0.1.0-alpha.15</version>
-            <classifier>${os.detected.classifier}</classifier>
+            <version>0.1.0-alpha.16</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -162,13 +161,6 @@
     </dependencies>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.0</version>
-            </extension>
-        </extensions>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>


### PR DESCRIPTION
Turns out OS resolution doesn't work correctly with transitive dependencies (aka, consumers of the Java SDK). So Yggdrasil can't be correctly resolved. This moves Ygg to a version that has all the binaries packed in so it doesn't need to care