### PR TITLE
chore: upgrade ubuntu 20.04 which is closing down

### DIFF
--- a/.github/workflows/publish_javadoc.yml
+++ b/.github/workflows/publish_javadoc.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   javadoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04.