### PR TITLE
fix: different interval headers are now sent for metrics/features

### DIFF
--- a/src/main/java/io/getunleash/metric/DefaultHttpMetricsSender.java
+++ b/src/main/java/io/getunleash/metric/DefaultHttpMetricsSender.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.concurrent.atomic.AtomicLong;
+import static io.getunleash.util.UnleashConfig.UNLEASH_INTERVAL;
 
 public class DefaultHttpMetricsSender implements MetricSender {
 
@@ -82,6 +83,7 @@ public class DefaultHttpMetricsSender implements MetricSender {
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Accept", "application/json");
             connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty(UNLEASH_INTERVAL, this.unleashConfig.getSendMetricsIntervalMillis());
             UnleashConfig.setRequestProperties(connection, this.unleashConfig);
             connection.setUseCaches(false);
             connection.setDoInput(true);

--- a/src/main/java/io/getunleash/metric/OkHttpMetricsSender.java
+++ b/src/main/java/io/getunleash/metric/OkHttpMetricsSender.java
@@ -19,6 +19,8 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
+import static io.getunleash.util.UnleashConfig.UNLEASH_INTERVAL;
+
 public class OkHttpMetricsSender implements MetricSender {
     private final UnleashConfig config;
     private final MediaType JSON =
@@ -88,7 +90,9 @@ public class OkHttpMetricsSender implements MetricSender {
 
     private int post(HttpUrl url, Object o) {
         RequestBody body = RequestBody.create(gson.toJson(o), JSON);
-        Request request = new Request.Builder().url(url).post(body).build();
+        Request request = new Request.Builder().url(url).post(body)
+            .addHeader(UNLEASH_INTERVAL, config.getSendMetricsIntervalMillis())
+            .build();
         try (Response response = this.client.newCall(request).execute()) {
             return response.code();
         } catch (IOException ioEx) {

--- a/src/main/java/io/getunleash/repository/HttpFeatureFetcher.java
+++ b/src/main/java/io/getunleash/repository/HttpFeatureFetcher.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.getunleash.util.UnleashConfig.UNLEASH_INTERVAL;
+
 public class HttpFeatureFetcher implements FeatureFetcher {
     private static final Logger LOG = LoggerFactory.getLogger(HttpFeatureFetcher.class);
     private Optional<String> etag = Optional.empty();
@@ -35,6 +37,7 @@ public class HttpFeatureFetcher implements FeatureFetcher {
         HttpURLConnection connection = null;
         try {
             connection = openConnection(this.toggleUrl);
+            connection.setRequestProperty(UNLEASH_INTERVAL, this.config.getFetchTogglesIntervalMillis());
             connection.connect();
 
             return getFeatureResponse(connection, true);

--- a/src/main/java/io/getunleash/repository/OkHttpFeatureFetcher.java
+++ b/src/main/java/io/getunleash/repository/OkHttpFeatureFetcher.java
@@ -21,10 +21,10 @@ import static io.getunleash.util.UnleashConfig.UNLEASH_INTERVAL;
 public class OkHttpFeatureFetcher implements FeatureFetcher {
     private final HttpUrl toggleUrl;
     private final OkHttpClient client;
-    private final UnleashConfig config;
+    private final String interval;
 
     public OkHttpFeatureFetcher(UnleashConfig unleashConfig) {
-        this.config = unleashConfig;
+        this.interval = unleashConfig.getFetchTogglesIntervalMillis();
         File tempDir = null;
         try {
             tempDir = Files.createTempDirectory("http_cache").toFile();
@@ -54,7 +54,7 @@ public class OkHttpFeatureFetcher implements FeatureFetcher {
     }
 
     public OkHttpFeatureFetcher(UnleashConfig unleashConfig, OkHttpClient client) {
-        this.config = unleashConfig;
+        this.interval = unleashConfig.getFetchTogglesIntervalMillis();
         this.client = OkHttpClientConfigurer.configureInterceptor(unleashConfig, client);
         this.toggleUrl =
                 Objects.requireNonNull(
@@ -69,7 +69,7 @@ public class OkHttpFeatureFetcher implements FeatureFetcher {
     @Override
     public ClientFeaturesResponse fetchFeatures() throws UnleashException {
         Request request = new Request.Builder().url(toggleUrl).get()
-            .addHeader(UNLEASH_INTERVAL, config.getFetchTogglesIntervalMillis())
+            .addHeader(UNLEASH_INTERVAL, interval)
             .build();
         int code = 200;
         try (Response response = client.newCall(request).execute()) {

--- a/src/main/java/io/getunleash/repository/OkHttpFeatureFetcher.java
+++ b/src/main/java/io/getunleash/repository/OkHttpFeatureFetcher.java
@@ -16,11 +16,15 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
+import static io.getunleash.util.UnleashConfig.UNLEASH_INTERVAL;
+
 public class OkHttpFeatureFetcher implements FeatureFetcher {
     private final HttpUrl toggleUrl;
     private final OkHttpClient client;
+    private final UnleashConfig config;
 
     public OkHttpFeatureFetcher(UnleashConfig unleashConfig) {
+        this.config = unleashConfig;
         File tempDir = null;
         try {
             tempDir = Files.createTempDirectory("http_cache").toFile();
@@ -50,6 +54,7 @@ public class OkHttpFeatureFetcher implements FeatureFetcher {
     }
 
     public OkHttpFeatureFetcher(UnleashConfig unleashConfig, OkHttpClient client) {
+        this.config = unleashConfig;
         this.client = OkHttpClientConfigurer.configureInterceptor(unleashConfig, client);
         this.toggleUrl =
                 Objects.requireNonNull(
@@ -63,7 +68,9 @@ public class OkHttpFeatureFetcher implements FeatureFetcher {
 
     @Override
     public ClientFeaturesResponse fetchFeatures() throws UnleashException {
-        Request request = new Request.Builder().url(toggleUrl).get().build();
+        Request request = new Request.Builder().url(toggleUrl).get()
+            .addHeader(UNLEASH_INTERVAL, config.getFetchTogglesIntervalMillis())
+            .build();
         int code = 200;
         try (Response response = client.newCall(request).execute()) {
             if (response.isSuccessful()) {

--- a/src/main/java/io/getunleash/util/OkHttpClientConfigurer.java
+++ b/src/main/java/io/getunleash/util/OkHttpClientConfigurer.java
@@ -21,9 +21,6 @@ public class OkHttpClientConfigurer {
                                                     UNLEASH_INSTANCE_ID_HEADER,
                                                     config.getInstanceId())
                                             .addHeader(
-                                                    UNLEASH_INTERVAL,
-                                                    config.getFetchTogglesIntervalMillis())
-                                            .addHeader(
                                                     UNLEASH_CONNECTION_ID_HEADER,
                                                     config.getConnectionId())
                                             .addHeader(UNLEASH_SDK_HEADER, config.getSdkVersion())

--- a/src/main/java/io/getunleash/util/UnleashConfig.java
+++ b/src/main/java/io/getunleash/util/UnleashConfig.java
@@ -185,7 +185,6 @@ public class UnleashConfig {
         config.customHttpHeadersProvider.getCustomHeaders().forEach(connection::setRequestProperty);
         // prevent overwrite
         connection.setRequestProperty(UNLEASH_CONNECTION_ID_HEADER, config.getConnectionId());
-        connection.setRequestProperty(UNLEASH_INTERVAL, config.getFetchTogglesIntervalMillis());
     }
 
     private void enableProxyAuthentication() {
@@ -241,6 +240,10 @@ public class UnleashConfig {
     public String getFetchTogglesIntervalMillis() {
         return String.valueOf(fetchTogglesInterval * 1000);
     }
+    public String getSendMetricsIntervalMillis() {
+        return String.valueOf(sendMetricsInterval * 1000);
+    }
+
 
     public Duration getFetchTogglesConnectTimeout() {
         return fetchTogglesConnectTimeout;

--- a/src/test/java/io/getunleash/metric/DefaultHttpMetricsSenderTest.java
+++ b/src/test/java/io/getunleash/metric/DefaultHttpMetricsSenderTest.java
@@ -74,7 +74,7 @@ public class DefaultHttpMetricsSenderTest {
                         .withRequestBody(matching(".*appName.*"))
                         .withRequestBody(matching(".*bucket.*"))
                         .withHeader(
-                                UNLEASH_INTERVAL, matching(config.getFetchTogglesIntervalMillis()))
+                                UNLEASH_INTERVAL, matching(config.getSendMetricsIntervalMillis()))
                         .withHeader(
                                 UNLEASH_CONNECTION_ID_HEADER, matching(config.getConnectionId()))
                         .withHeader("UNLEASH-APPNAME", matching("test-app")));
@@ -93,7 +93,7 @@ public class DefaultHttpMetricsSenderTest {
                 UnleashConfig.builder()
                         .appName("test-app")
                         .unleashAPI(uri)
-                        .fetchTogglesInterval(metricsInterval)
+                        .sendMetricsInterval(metricsInterval)
                         .build();
 
         DefaultHttpMetricsSender sender = new DefaultHttpMetricsSender(config);

--- a/src/test/java/io/getunleash/util/UnleashConfigTest.java
+++ b/src/test/java/io/getunleash/util/UnleashConfigTest.java
@@ -156,8 +156,6 @@ public class UnleashConfigTest {
         UnleashConfig.setRequestProperties(connection, unleashConfig);
         assertThat(connection.getRequestProperty(UNLEASH_APP_NAME_HEADER)).isEqualTo(appName);
         assertThat(connection.getRequestProperty(UNLEASH_INSTANCE_ID_HEADER)).isEqualTo(instanceId);
-        assertThat(connection.getRequestProperty(UNLEASH_INTERVAL))
-                .isEqualTo(unleashConfig.getFetchTogglesIntervalMillis());
         assertThat(connection.getRequestProperty(UNLEASH_CONNECTION_ID_HEADER))
                 .isEqualTo(unleashConfig.getConnectionId());
         assertThat(connection.getRequestProperty(UNLEASH_SDK_HEADER))


### PR DESCRIPTION
Previously same interval was sent to both requests, metrics and features. Now for metrics we are sending metrics interval and for feature fetching, we send refreshInterval.