### PR TITLE
Conditionally enable features based on contexts

### DIFF
--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -115,12 +115,14 @@ public class FakeUnleash implements Unleash {
 
     public void enable(String... features) {
         for (String name : features) {
+            this.conditionalFeatures.remove(name);
             this.features.put(name, true);
         }
     }
 
     public void disable(String... features) {
         for (String name : features) {
+            this.conditionalFeatures.remove(name);
             this.features.put(name, false);
         }
     }

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -5,6 +5,7 @@ import io.getunleash.variant.Variant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class FakeUnleash implements Unleash {
@@ -15,7 +16,8 @@ public class FakeUnleash implements Unleash {
      * @implNote This uses {@link Queue} instead of {@link List}, as there are concurrent queues,
      *     but no concurrent lists in the jdk.
      */
-    private final Map<String, Queue<FakeContextMatcher>> features = new ConcurrentHashMap<>();
+    private final Map<String, Queue<Predicate<UnleashContext>>> features =
+            new ConcurrentHashMap<>();
 
     private final Map<String, Variant> variants = new ConcurrentHashMap<>();
 
@@ -47,12 +49,12 @@ public class FakeUnleash implements Unleash {
         } else if (disableAll) {
             return excludedFeatures.getOrDefault(toggleName, false);
         } else {
-            Queue<FakeContextMatcher> fakeContextMatchers = features.get(toggleName);
-            if (fakeContextMatchers == null) {
+            Queue<Predicate<UnleashContext>> contextMatchers = features.get(toggleName);
+            if (contextMatchers == null) {
                 return fallbackAction.test(toggleName, context);
             } else {
-                return fakeContextMatchers.stream()
-                        .anyMatch(fakeContextMatcher -> fakeContextMatcher.matches(context));
+                return contextMatchers.stream()
+                        .anyMatch(fakeContextMatcher -> fakeContextMatcher.test(context));
             }
         }
     }
@@ -124,13 +126,13 @@ public class FakeUnleash implements Unleash {
 
     public void enable(String... features) {
         for (String name : features) {
-            this.features.put(name, only(FakeContextMatcher.ALWAYS));
+            this.features.put(name, only(context -> true));
         }
     }
 
     public void disable(String... features) {
         for (String name : features) {
-            this.features.put(name, only(FakeContextMatcher.NEVER));
+            this.features.put(name, only(context -> false));
         }
     }
 
@@ -141,23 +143,24 @@ public class FakeUnleash implements Unleash {
     }
 
     /**
-     * Enables or disables feature toggles depending on the evaluation of the {@link
-     * FakeContextMatcher contextMatcher}. This can be called multiple times, and the combined state
-     * will be examined. This lets you conditionally configure multiple different tests to do
-     * different things, while running concurrently. This will be overwritten if {@link
+     * Enables or disables feature toggles depending on the evaluation of the {@code
+     * contextMatcher}. This can be called multiple times. If <b>any</b> of the context matchers
+     * match, the feature is enabled. This lets you conditionally configure multiple different tests
+     * to do different things, while running concurrently. This will be overwritten if {@link
      * #enable(String...)} or {@link #disable(String...)} are called.
      *
      * @param contextMatcher the context matcher to evaluate
      * @param features the features for which the context matcher will be invoked
      */
-    public void conditionallyEnable(FakeContextMatcher contextMatcher, String... features) {
+    public void conditionallyEnable(Predicate<UnleashContext> contextMatcher, String... features) {
         for (String name : features) {
             this.features.computeIfAbsent(name, ignored -> new ArrayDeque<>()).add(contextMatcher);
         }
     }
 
-    private static Queue<FakeContextMatcher> only(FakeContextMatcher fakeContextMatcher) {
-        Queue<FakeContextMatcher> only = new ArrayDeque<>();
+    private static Queue<Predicate<UnleashContext>> only(
+            Predicate<UnleashContext> fakeContextMatcher) {
+        Queue<Predicate<UnleashContext>> only = new ArrayDeque<>();
         only.add(fakeContextMatcher);
         return only;
     }
@@ -201,53 +204,5 @@ public class FakeUnleash implements Unleash {
                                             getVariant(toggleName)))
                     .collect(Collectors.toList());
         }
-    }
-
-    /**
-     * Matches a context provided to {@link Unleash#isEnabled(String, UnleashContext)} and related
-     * methods with a context provided to {@link FakeUnleash#conditionallyEnable(FakeContextMatcher,
-     * String...)} and related methods.
-     */
-    public interface FakeContextMatcher {
-        /**
-         * Always matches any context provided. This is useful when enabling a feature toggle
-         * regardless of the context.
-         */
-        FakeContextMatcher ALWAYS = context -> true;
-        /**
-         * Never matches any context provided. This is useful when disabling a feature toggle
-         * regardless of the context.
-         */
-        FakeContextMatcher NEVER = context -> false;
-
-        /**
-         * If all you want to do is match a provided context exactly, this is a shortcut method to
-         * do just that.
-         *
-         * @param expectedContext the context you want to match
-         * @return a matcher that returns {@code true} iff the {@code expectedContext} is equal to
-         *     the {@code actualContext}.
-         */
-        static FakeContextMatcher equals(UnleashContext expectedContext) {
-            return new FakeContextMatcher() {
-                @Override
-                public boolean matches(UnleashContext actualContext) {
-                    return Objects.equals(
-                            expectedContext.getProperties(), actualContext.getProperties());
-                }
-            };
-        }
-
-        /**
-         * Evaluate if the context provided to {@link Unleash#isEnabled(String, UnleashContext)} and
-         * related methods matches the conditions you set. This is for more complex configurations
-         * than what {@link #equals(UnleashContext)} offers.
-         *
-         * @param context the context passed to {@link Unleash#isEnabled(String, UnleashContext)}
-         *     and related methods. This is empty but not null if no context was provided, such as
-         *     when calling {@link Unleash#isEnabled(String)}
-         * @return {@code true} iff {@code context} matches the check, otherwise {@code false}.
-         */
-        boolean matches(UnleashContext context);
     }
 }

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -4,6 +4,7 @@ import io.getunleash.lang.Nullable;
 import io.getunleash.variant.Variant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -158,7 +159,7 @@ public class FakeUnleash implements Unleash {
             // calling conditionallyEnable() should override having called enable() or disable()
             this.features.remove(name);
             this.conditionalFeatures
-                    .computeIfAbsent(name, ignored -> new ArrayDeque<>())
+                    .computeIfAbsent(name, ignored -> new LinkedBlockingQueue<>())
                     .add(contextMatcher);
         }
     }

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -81,6 +81,7 @@ public class FakeUnleash implements Unleash {
     public void enableAll() {
         disableAll = false;
         enableAll = true;
+        features.clear();
         excludedFeatures.clear();
         conditionalFeatures.clear();
     }
@@ -95,6 +96,7 @@ public class FakeUnleash implements Unleash {
     public void disableAll() {
         disableAll = true;
         enableAll = false;
+        features.clear();
         excludedFeatures.clear();
         conditionalFeatures.clear();
     }

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -3,15 +3,21 @@ package io.getunleash;
 import io.getunleash.lang.Nullable;
 import io.getunleash.variant.Variant;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 public class FakeUnleash implements Unleash {
     private boolean enableAll = false;
     private boolean disableAll = false;
-    private Map<String, Boolean> excludedFeatures = new HashMap<>();
-    private Map<String, Boolean> features = new HashMap<>();
-    private Map<String, Variant> variants = new HashMap<>();
+    private final Map<String, Boolean> excludedFeatures = new ConcurrentHashMap<>();
+    /**
+     * @implNote This uses {@link Queue} instead of {@link List}, as there are concurrent queues,
+     *     but no concurrent lists in the jdk.
+     */
+    private final Map<String, Queue<FakeContextMatcher>> features = new ConcurrentHashMap<>();
+
+    private final Map<String, Variant> variants = new ConcurrentHashMap<>();
 
     @Override
     public boolean isEnabled(String toggleName, boolean defaultSetting) {
@@ -20,7 +26,13 @@ public class FakeUnleash implements Unleash {
         } else if (disableAll) {
             return excludedFeatures.getOrDefault(toggleName, false);
         } else {
-            return features.containsKey(toggleName) ? features.get(toggleName) : defaultSetting;
+            Queue<FakeContextMatcher> fakeContextMatchers = features.get(toggleName);
+            if (fakeContextMatchers == null) {
+                return defaultSetting;
+            } else {
+                return fakeContextMatchers.stream()
+                        .anyMatch(fakeContextMatcher -> fakeContextMatcher.matches(null));
+            }
         }
     }
 
@@ -29,7 +41,16 @@ public class FakeUnleash implements Unleash {
             String toggleName,
             UnleashContext context,
             BiPredicate<String, UnleashContext> fallbackAction) {
-        return isEnabled(toggleName, fallbackAction);
+        if (!enableAll && !disableAll || excludedFeatures.containsKey(toggleName)) {
+            Queue<FakeContextMatcher> fakeContextMatchers = features.get(toggleName);
+            if (fakeContextMatchers == null) {
+                return fallbackAction.test(toggleName, UnleashContext.builder().build());
+            } else {
+                return fakeContextMatchers.stream()
+                        .anyMatch(fakeContextMatcher -> fakeContextMatcher.matches(context));
+            }
+        }
+        return isEnabled(toggleName);
     }
 
     @Override
@@ -109,13 +130,13 @@ public class FakeUnleash implements Unleash {
 
     public void enable(String... features) {
         for (String name : features) {
-            this.features.put(name, true);
+            this.features.put(name, only(FakeContextMatcher.ALWAYS));
         }
     }
 
     public void disable(String... features) {
         for (String name : features) {
-            this.features.put(name, false);
+            this.features.put(name, only(FakeContextMatcher.NEVER));
         }
     }
 
@@ -123,6 +144,28 @@ public class FakeUnleash implements Unleash {
         for (String name : features) {
             this.features.remove(name);
         }
+    }
+
+    /**
+     * Enables or disables feature toggles depending on the evaluation of the {@link
+     * FakeContextMatcher contextMatcher}. This can be called multiple times, and the combined state
+     * will be examined. This lets you conditionally configure multiple different tests to do
+     * different things, while running concurrently. This will be overwritten if {@link
+     * #enable(String...)} or {@link #disable(String...)} are called.
+     *
+     * @param contextMatcher the context matcher to evaluate
+     * @param features the features for which the context matcher will be invoked
+     */
+    public void conditionallyEnable(FakeContextMatcher contextMatcher, String... features) {
+        for (String name : features) {
+            this.features.computeIfAbsent(name, ignored -> new ArrayDeque<>()).add(contextMatcher);
+        }
+    }
+
+    private static Queue<FakeContextMatcher> only(FakeContextMatcher fakeContextMatcher) {
+        Queue<FakeContextMatcher> only = new ArrayDeque<>();
+        only.add(fakeContextMatcher);
+        return only;
     }
 
     public void setVariant(String t1, Variant a) {
@@ -164,5 +207,57 @@ public class FakeUnleash implements Unleash {
                                             getVariant(toggleName)))
                     .collect(Collectors.toList());
         }
+    }
+
+    /**
+     * Matches a context provided to {@link Unleash#isEnabled(String, UnleashContext)} and related
+     * methods with a context provided to {@link FakeUnleash#conditionallyEnable(FakeContextMatcher,
+     * String...)} and related methods.
+     */
+    public interface FakeContextMatcher {
+        /**
+         * Always matches any context provided. This is useful when enabling a feature toggle
+         * regardless of the context.
+         */
+        FakeContextMatcher ALWAYS = context -> true;
+        /**
+         * Never matches any context provided. This is useful when disabling a feature toggle
+         * regardless of the context.
+         */
+        FakeContextMatcher NEVER = context -> false;
+
+        /**
+         * If all you want to do is match a provided context exactly, this is a shortcut method to
+         * do just that.
+         *
+         * @param expectedContext the context you want to match
+         * @return a matcher that returns {@code true} iff the {@code expectedContext} is equal to
+         *     the {@code actualContext}. If no context is passed, such as when using {@link
+         *     Unleash#isEnabled(String)}, this method will return {@code false}.
+         */
+        static FakeContextMatcher equals(UnleashContext expectedContext) {
+            return new FakeContextMatcher() {
+                @Override
+                public boolean matches(@Nullable UnleashContext actualContext) {
+                    if (actualContext == null) {
+                        return false;
+                    }
+                    return Objects.equals(
+                            expectedContext.getProperties(), actualContext.getProperties());
+                }
+            };
+        }
+
+        /**
+         * Evaluate if the context provided to {@link Unleash#isEnabled(String, UnleashContext)} and
+         * related methods matches the conditions you set. This is for more complex configurations
+         * than what {@link #equals(UnleashContext)} offers.
+         *
+         * @param context the context passed to {@link Unleash#isEnabled(String, UnleashContext)}
+         *     and related methods. This is {@code null} is no context was provided, such as when
+         *     calling {@link Unleash#isEnabled(String)}
+         * @return {@code true} iff {@code context} matches the check, otherwise {@code false}.
+         */
+        boolean matches(@Nullable UnleashContext context);
     }
 }

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -14,7 +14,7 @@ public class FakeUnleash implements Unleash {
     private final Map<String, Boolean> excludedFeatures = new ConcurrentHashMap<>();
     /**
      * @implNote This uses {@link Queue} instead of {@link List}, as there are concurrent queues,
-     *     but no concurrent lists in the jdk.
+     *     but no concurrent lists, in the jdk. This will never be drained. Only iterated over.
      */
     private final Map<String, Queue<Predicate<UnleashContext>>> features =
             new ConcurrentHashMap<>();

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -49,12 +49,18 @@ public class FakeUnleash implements Unleash {
 
     @Override
     public Variant getVariant(String toggleName, UnleashContext context) {
-        return getVariant(toggleName, Variant.DISABLED_VARIANT);
+        return getVariant(toggleName, context, Variant.DISABLED_VARIANT);
     }
 
     @Override
     public Variant getVariant(String toggleName, UnleashContext context, Variant defaultValue) {
-        return getVariant(toggleName, defaultValue);
+        if (isEnabled(toggleName, context)) {
+            Variant variant = variants.get(toggleName);
+            if (variant != null) {
+                return variant;
+            }
+        }
+        return defaultValue;
     }
 
     @Override
@@ -64,11 +70,7 @@ public class FakeUnleash implements Unleash {
 
     @Override
     public Variant getVariant(String toggleName, Variant defaultValue) {
-        if (isEnabled(toggleName) && variants.containsKey(toggleName)) {
-            return variants.get(toggleName);
-        } else {
-            return defaultValue;
-        }
+        return getVariant(toggleName, UnleashContext.builder().build(), defaultValue);
     }
 
     @Override
@@ -156,8 +158,8 @@ public class FakeUnleash implements Unleash {
         }
     }
 
-    public void setVariant(String t1, Variant a) {
-        variants.put(t1, a);
+    public void setVariant(String toggleName, Variant variant) {
+        variants.put(toggleName, variant);
     }
 
     public class FakeMore implements MoreOperations {

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -22,25 +22,7 @@ public class FakeUnleash implements Unleash {
     private final Map<String, Variant> variants = new ConcurrentHashMap<>();
 
     @Override
-    public boolean isEnabled(String toggleName, boolean defaultSetting) {
-        return isEnabled0(toggleName, UnleashContext.builder().build(), (t, c) -> defaultSetting);
-    }
-
-    @Override
     public boolean isEnabled(
-            String toggleName,
-            UnleashContext context,
-            BiPredicate<String, UnleashContext> fallbackAction) {
-        return isEnabled0(toggleName, context, fallbackAction);
-    }
-
-    @Override
-    public boolean isEnabled(
-            String toggleName, BiPredicate<String, UnleashContext> fallbackAction) {
-        return isEnabled0(toggleName, UnleashContext.builder().build(), fallbackAction);
-    }
-
-    private boolean isEnabled0(
             String toggleName,
             UnleashContext context,
             BiPredicate<String, UnleashContext> fallbackAction) {

--- a/src/main/java/io/getunleash/FakeUnleash.java
+++ b/src/main/java/io/getunleash/FakeUnleash.java
@@ -37,12 +37,15 @@ public class FakeUnleash implements Unleash {
             if (unconditionallyEnabled != null) {
                 return unconditionallyEnabled;
             }
-            Queue<Predicate<UnleashContext>> contextMatchers = conditionalFeatures.get(toggleName);
-            if (contextMatchers == null) {
+            Queue<Predicate<UnleashContext>> conditionalFeaturePredicates =
+                    conditionalFeatures.get(toggleName);
+            if (conditionalFeaturePredicates == null) {
                 return fallbackAction.test(toggleName, context);
             } else {
-                return contextMatchers.stream()
-                        .anyMatch(fakeContextMatcher -> fakeContextMatcher.test(context));
+                return conditionalFeaturePredicates.stream()
+                        .anyMatch(
+                                conditionalFeaturePredicate ->
+                                        conditionalFeaturePredicate.test(context));
             }
         }
     }

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -2,7 +2,6 @@ package io.getunleash;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.getunleash.lang.Nullable;
 import io.getunleash.variant.Variant;
 import java.util.Arrays;
 import java.util.List;
@@ -18,12 +17,12 @@ public class FakeUnleashTest {
         fakeUnleash.conditionallyEnable(
                 new FakeUnleash.FakeContextMatcher() {
                     @Override
-                    public boolean matches(@Nullable UnleashContext context) {
-                        if (context == null) {
-                            return false;
-                        }
+                    public boolean matches(UnleashContext context) {
                         Map<String, String> properties = context.getProperties();
                         String testProperty = properties.get("test");
+                        if (testProperty == null) {
+                            return false;
+                        }
                         return testProperty.equals("expected_test_value");
                     }
                 },

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -10,6 +10,61 @@ import org.junit.jupiter.api.Test;
 
 public class FakeUnleashTest {
 
+    /**
+     * If it doesn't, then we keep "always enabled" in the list of conditions, and since we OR them
+     * together, the conditional feature toggle is effectively ignored.
+     */
+    @Test
+    void conditionally_enabling_a_feature_should_replace_always_enabled() throws Exception {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.enable("t1");
+        fakeUnleash.conditionallyEnable(
+                context -> "expected_test_value".equals(context.getProperties().get("test")), "t1");
+
+        assertThat(
+                        fakeUnleash.isEnabled(
+                                "t1",
+                                UnleashContext.builder()
+                                        .addProperty("test", "expected_test_value")
+                                        .build()))
+                .isTrue();
+        assertThat(
+                        fakeUnleash.isEnabled(
+                                "t1",
+                                UnleashContext.builder()
+                                        .addProperty("test", "unexpected_test_value")
+                                        .build()))
+                .isFalse();
+    }
+
+    /**
+     * If it doesn't, then we keep "always enabled" in the list of conditions, and since we OR them
+     * together, the conditional feature toggle is effectively ignored.
+     */
+    @Test
+    void unconditionally_enabling_a_feature_should_replace_conditionally_enabled()
+            throws Exception {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+        fakeUnleash.conditionallyEnable(
+                context -> "expected_test_value".equals(context.getProperties().get("test")), "t1");
+        fakeUnleash.enable("t1");
+
+        assertThat(
+                        fakeUnleash.isEnabled(
+                                "t1",
+                                UnleashContext.builder()
+                                        .addProperty("test", "expected_test_value")
+                                        .build()))
+                .isTrue();
+        assertThat(
+                        fakeUnleash.isEnabled(
+                                "t1",
+                                UnleashContext.builder()
+                                        .addProperty("test", "unexpected_test_value")
+                                        .build()))
+                .isTrue();
+    }
+
     @Test
     void should_evaluate_against_context_if_conditionally_enabled() throws Exception {
         FakeUnleash fakeUnleash = new FakeUnleash();

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -151,6 +151,18 @@ public class FakeUnleashTest {
     }
 
     @Test
+    void should_use_fallback_if_no_matchers_defined() {
+        FakeUnleash fakeUnleash = new FakeUnleash();
+
+        assertThat(
+                        fakeUnleash.isEnabled(
+                                "unknown-toggle",
+                                UnleashContext.builder().addProperty("test", "v1").build(),
+                                (name, context) -> true))
+                .isTrue();
+    }
+
+    @Test
     public void should_enable_all_toggles() throws Exception {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.enableAll();

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -10,10 +10,6 @@ import org.junit.jupiter.api.Test;
 
 public class FakeUnleashTest {
 
-    /**
-     * If it doesn't, then we keep "always enabled" in the list of conditions, and since we OR them
-     * together, the conditional feature toggle is effectively ignored.
-     */
     @Test
     void conditionally_enabling_a_feature_should_replace_always_enabled() throws Exception {
         FakeUnleash fakeUnleash = new FakeUnleash();
@@ -37,10 +33,6 @@ public class FakeUnleashTest {
                 .isFalse();
     }
 
-    /**
-     * If it doesn't, then we keep "always enabled" in the list of conditions, and since we OR them
-     * together, the conditional feature toggle is effectively ignored.
-     */
     @Test
     void unconditionally_enabling_a_feature_should_replace_conditionally_enabled()
             throws Exception {

--- a/src/test/java/io/getunleash/FakeUnleashTest.java
+++ b/src/test/java/io/getunleash/FakeUnleashTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.getunleash.variant.Variant;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
@@ -15,17 +14,7 @@ public class FakeUnleashTest {
     void should_evaluate_against_context_if_conditionally_enabled() throws Exception {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.conditionallyEnable(
-                new FakeUnleash.FakeContextMatcher() {
-                    @Override
-                    public boolean matches(UnleashContext context) {
-                        Map<String, String> properties = context.getProperties();
-                        String testProperty = properties.get("test");
-                        if (testProperty == null) {
-                            return false;
-                        }
-                        return testProperty.equals("expected_test_value");
-                    }
-                },
+                context -> "expected_test_value".equals(context.getProperties().get("test")),
                 "t1",
                 "t2");
 
@@ -50,50 +39,12 @@ public class FakeUnleashTest {
     }
 
     @Test
-    void should_evaluate_against_context_if_conditionally_enabled_using_equals() throws Exception {
-        FakeUnleash fakeUnleash = new FakeUnleash();
-        fakeUnleash.conditionallyEnable(
-                FakeUnleash.FakeContextMatcher.equals(
-                        UnleashContext.builder()
-                                .addProperty("test", "expected_test_value")
-                                .build()),
-                "t1",
-                "t2");
-
-        // Matches because the context is an exact match
-        assertThat(
-                        fakeUnleash.isEnabled(
-                                "t1",
-                                UnleashContext.builder()
-                                        .addProperty("test", "expected_test_value")
-                                        .build()))
-                .isTrue();
-        // Does not match because the context has extra properties
-        assertThat(
-                        fakeUnleash.isEnabled(
-                                "t2",
-                                UnleashContext.builder()
-                                        .addProperty("test", "expected_test_value")
-                                        .addProperty("other", "other")
-                                        .build()))
-                .isFalse();
-        assertThat(fakeUnleash.isEnabled("t1")).isFalse();
-        assertThat(fakeUnleash.isEnabled("unknown")).isFalse();
-    }
-
-    @Test
     void should_evaluate_multiple_conditional_contexts() throws Exception {
         FakeUnleash fakeUnleash = new FakeUnleash();
         fakeUnleash.conditionallyEnable(
-                FakeUnleash.FakeContextMatcher.equals(
-                        UnleashContext.builder().addProperty("test", "v1").build()),
-                "t1",
-                "t2");
+                context -> "v1".equals(context.getProperties().get("test")), "t1", "t2");
         fakeUnleash.conditionallyEnable(
-                FakeUnleash.FakeContextMatcher.equals(
-                        UnleashContext.builder().addProperty("test", "v2").build()),
-                "t1",
-                "t2");
+                context -> "v2".equals(context.getProperties().get("test")), "t1", "t2");
 
         assertThat(
                         fakeUnleash.isEnabled(


### PR DESCRIPTION
## About the changes
Conditionally enable feature toggles based on matching the context. 
See https://github.com/Unleash/unleash-client-java/issues/266

### Important files
* FakeUnleash
* FakeUnleashTest


## Discussion points
We assume that we will want to define *multiple* conditions concurrently, because that's how unleash works in reality. As a result, `FakeUnleash.conditionallyEnable()` can be called multiple times, and these conditions are ORed together. That way one test can say "enable for x=1" and another says "enable for y=2", and these can co-exist without affecting each other.

We assume that enabling or disabling a feature toggle without specifying a context wipes out any conditionally enabled configurations for the same feature toggles, and vice versa. See the difference between `features` and `conditionalFeatures`

We also assume that we need to be able to do this concurrently in terms of execution, hence the use of concurrent classes in FakeUnleash.
