### PR TITLE
fix: add null check before sending metrics

### DIFF
--- a/src/main/java/io/getunleash/metric/ClientMetrics.java
+++ b/src/main/java/io/getunleash/metric/ClientMetrics.java
@@ -12,14 +12,14 @@ public class ClientMetrics implements UnleashEvent {
     private final String appName;
     private final String instanceId;
     private final String connectionId;
-    private final MetricsBucket bucket;
+    @Nullable private final MetricsBucket bucket;
     private final String environment;
     private final String specVersion;
     @Nullable private final String platformName;
     @Nullable private final String platformVersion;
     @Nullable private final String yggdrasilVersion;
 
-    ClientMetrics(UnleashConfig config, MetricsBucket bucket) {
+    ClientMetrics(UnleashConfig config, @Nullable MetricsBucket bucket) {
         this.environment = config.getEnvironment();
         this.appName = config.getAppName();
         this.instanceId = config.getInstanceId();
@@ -43,6 +43,7 @@ public class ClientMetrics implements UnleashEvent {
         return connectionId;
     }
 
+    @Nullable
     public MetricsBucket getBucket() {
         return bucket;
     }

--- a/src/main/java/io/getunleash/metric/DefaultHttpMetricsSender.java
+++ b/src/main/java/io/getunleash/metric/DefaultHttpMetricsSender.java
@@ -56,7 +56,7 @@ public class DefaultHttpMetricsSender implements MetricSender {
     }
 
     public int sendMetrics(ClientMetrics metrics) {
-        if (!unleashConfig.isDisableMetrics()) {
+        if (!unleashConfig.isDisableMetrics() && metrics.getBucket() != null) {
             try {
                 int statusCode = post(clientMetricsURL, metrics);
                 eventDispatcher.dispatch(metrics);

--- a/src/test/java/io/getunleash/event/SubscriberTest.java
+++ b/src/test/java/io/getunleash/event/SubscriberTest.java
@@ -78,7 +78,6 @@ public class SubscriberTest {
         assertThat(testSubscriber.events)
                 .filteredOn(e -> e instanceof ClientRegistration)
                 .hasSize(1);
-        assertThat(testSubscriber.events).filteredOn(e -> e instanceof ClientMetrics).hasSize(1);
     }
 
     private class TestSubscriber implements UnleashSubscriber {


### PR DESCRIPTION
Seems like the engine can return null when there are no metrics to send. Updated the type signature to say that the bucket is nullable and added an is-not-null check before sending metrics to avoid 400's.


Fixes #301 