### PR TITLE
chore: upgrade spring-boot-sample to unleash 10

### DIFF
--- a/examples/spring-boot-example/build.gradle.kts
+++ b/examples/spring-boot-example/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 dependencies {
   implementation("org.springframework.boot:spring-boot-starter-web")
-  implementation("io.getunleash:unleash-client-java:9.1.1")
+  implementation("io.getunleash:unleash-client-java:10.2.2")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/examples/spring-boot-example/src/main/java/io/getunleash/unleash/example/ProxyController.java
+++ b/examples/spring-boot-example/src/main/java/io/getunleash/unleash/example/ProxyController.java
@@ -1,10 +1,10 @@
 package io.getunleash.unleash.example;
 
 import io.getunleash.Unleash;
-import jakarta.websocket.server.PathParam;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,7 +33,7 @@ public class ProxyController {
     }
 
     @GetMapping("/toggle/{toggleName}")
-    public Boolean getToggle(@PathParam("toggleName") String name) {
+    public Boolean getToggle(@PathVariable("toggleName") String name) {
         return unleash.isEnabled(name);
     }
 

--- a/examples/spring-boot-example/src/main/resources/application.yaml
+++ b/examples/spring-boot-example/src/main/resources/application.yaml
@@ -1,4 +1,4 @@
 unleash:
     url: https://app.unleash-hosted.com/demo/api
-    apiKey: demo-app:production.614a75cf68bef8703aa1bd8304938a81ec871f86ea40c975468eabd6
+    apiKey: "*:development.25a06b75248528f8ca93ce179dcdd141aedfb632231e0d21fd8ff349"
     appname: "Java-Spring-Boot-example"


### PR DESCRIPTION
This is an attempt to verify #288 with SpringBoot: `./gradlew bootRun` and accessing `http://localhost:8080/all` that evaluates all toggles at once.

The result was unsuccessful as I couldn't reproduce the issue. 

I also tried locally with a custom header and without synchronousFetchOnInitialisation:
```java
        UnleashConfig config = UnleashConfig.builder().unleashAPI(url).appName(appName)
            //.apiKey(apiKey)
            .customHttpHeader("Authorization", apiKey)
            .instanceId("spring-boot-example")
            .environment("development")
            //.synchronousFetchOnInitialisation(true)
            .fetchTogglesInterval(15).build();
```

Still the PR is valid to bump the examples