### PR TITLE
docs: java version notes

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -6,13 +6,9 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        version: [8, 11, 17]
+        version: [11, 17]
         os: ["ubuntu", "windows", "macos"]
-        exclude:
-        - version: 8
-          os: macos
-        - version: 8
-          os: windows
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You can use this client with [Unleash Enterprise](https://www.getunleash.io/pric
 
 ## Java Version Compatibility
 
-As of version 10.2.3, this library requires Java 11 or newer.
+As of version 11, this library requires Java 11 or newer.
 
-- Java 8+ is supported on versions 10.2.2 and below
+- Java 8+ is supported on versions 10.2.x and below
 
-- Java 11+ is required starting from 10.2.3
+- Java 11+ is required starting from version 11 of the SDK
 
 If you're using Java 8, please pin your dependency to 10.2.2 or earlier.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ You can use this client with [Unleash Enterprise](https://www.getunleash.io/pric
 >
 > If you're using `MoreOperations`, custom or fallback strategies, subscribers or bootstrapping, please see the full [migration guide](v10_MIGRATION_GUIDE.md) for details. If you use GraalVM or Quarkus, please hold off on upgrading to v10, support is planned but not implemented.
 
+## Java Version Compatibility
+
+As of version 10.2.3, this library requires Java 11 or newer.
+
+- Java 8+ is supported on versions 10.2.2 and below
+
+- Java 11+ is supported starting from 10.2.3
+
+If you're using Java 8, please pin your dependency to 10.2.2 or earlier.
+
 ## Getting started
 
 This section shows you how to get started quickly and explains some common configuration scenarios. For a full overview of Unleash configuration options, check out [the _Configuration options_ section](#configuration-options).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As of version 10.2.3, this library requires Java 11 or newer.
 
 - Java 8+ is supported on versions 10.2.2 and below
 
-- Java 11+ is supported starting from 10.2.3
+- Java 11+ is required starting from 10.2.3
 
 If you're using Java 8, please pin your dependency to 10.2.2 or earlier.
 


### PR DESCRIPTION
Drops official support for Java 8

- Notes in docs about supported Java
- Removed Java 8 from build runners for PRs