### PR TITLE
chore: remove java 8 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [8, 11, 17]
+        version: [11, 17]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Release 11 dropped support for Java 8. Removing that from main build steps