### PR TITLE
chore: add a deprecation notice to environment

### DIFF
--- a/src/main/java/io/getunleash/util/UnleashConfig.java
+++ b/src/main/java/io/getunleash/util/UnleashConfig.java
@@ -517,6 +517,12 @@ public class UnleashConfig {
             return this;
         }
 
+        /**
+         * @deprecated Environment is a first class citizen in Unleash 4.0.0 and later. From v13.0.0
+         *     of the Java SDK, this will be computed from the API key provided instead of being
+         *     manually set.
+         */
+        @Deprecated(since = "12.0.0", forRemoval = true)
         public Builder environment(String environment) {
             this.environment = environment;
             return this;


### PR DESCRIPTION
Marks the environment on the config as deprecated. This has been a first class citizen in Unleash for a very, very long time and manually setting it is silly. However, this can affect constraints so it's not a safe and quick change