### PR TITLE
chore(deps): bump okhttp-eventsource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.launchdarkly</groupId>
             <artifactId>okhttp-eventsource</artifactId>
-            <version>4.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The old version relies on `okhttp v 4.9.3` which is marked as security issue in Sonatype. `4.3.0` relies on the same version as already defined in the `pom.xml` - `4.12.0`

Reported issues are located in:
- `com.squareup.okio : okio : 2.8.0`
- `org.jetbrains.kotlin : kotlin-stdlib : 1.4.10`

<img width="532" height="237" alt="Screenshot 2026-04-14 at 08 48 11" src="https://github.com/user-attachments/assets/c9959e9a-cd5c-4969-bc7c-be64be81d215" />
<img width="453" height="153" alt="Screenshot 2026-04-14 at 08 47 57" src="https://github.com/user-attachments/assets/92fa72a5-124b-4b4c-b697-dbc57e5232fc" />

Fixes: #375